### PR TITLE
Update Arsenal.cs

### DIFF
--- a/trunk/DefaultCombat/Routines/Advanced/Mercenary/Arsenal.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Mercenary/Arsenal.cs
@@ -19,7 +19,6 @@ namespace DefaultCombat.Routines
 			get
 			{
 				return new PrioritySelector(
-					Spell.Buff("High Velocity Gas Cylinder"),
 					Spell.Buff("Hunter's Boon")
 					);
 			}
@@ -34,7 +33,8 @@ namespace DefaultCombat.Routines
 					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
 					Spell.Buff("Supercharged Gas", ret => Me.BuffCount("Supercharge") == 10),
 					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30)
+					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+					Spell.Buff("Responsive Safeguards", ret => Me.HealthPercent <= 50)
 					);
 			}
 		}
@@ -71,7 +71,6 @@ namespace DefaultCombat.Routines
 						Spell.Buff("Power Surge"),
 						Spell.CastOnGround("Death from Above"),
 						Spell.Cast("Fusion Missile", ret => Me.ResourcePercent() <= 10 && Me.HasBuff("Power Surge")),
-						Spell.Cast("Flame Thrower", ret => Me.CurrentTarget.Distance <= 1f),
 						Spell.CastOnGround("Sweeping Blasters", ret => Me.ResourcePercent() <= 10))
 					);
 			}


### PR DESCRIPTION
Fixes for 5.0:
Remove line 22 - High Velocity Gas Cylinder is now a passive ability, replacing Combustible Gas Cylinder.
Added line 38 - Responsive Safeguards - new active ability (adjust order in rotation as needed)
Remove line 74 - Flame Thrower has been renamed Searing Wave, redesigned, and is now Powertech exclusive.