### PR TITLE
Update ShieldTech.cs

### DIFF
--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
@@ -53,7 +53,6 @@ namespace DefaultCombat.Routines
 						new PrioritySelector(
 							Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
 							Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-							Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
 							Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Surge")),
 							Spell.Cast("Rapid Shots")
 							)),
@@ -66,7 +65,6 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Rocket Punch"),
 					Spell.Cast("Rail Shot"),
 					Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-					Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
 					Spell.Cast("Flame Burst")
 					);
 			}
@@ -85,7 +83,6 @@ namespace DefaultCombat.Routines
 						new PrioritySelector(
 							Spell.Cast("Shatter Slug"),
 							Spell.Cast("Firestorm", ret => Me.Level >= 57),
-							Spell.Cast("Searing Wave", ret => Me.Level < 57),
 							Spell.Cast("Flame Sweep")
 							)));
 			}

--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
@@ -19,7 +19,6 @@ namespace DefaultCombat.Routines
 			get
 			{
 				return new PrioritySelector(
-					Spell.Buff("Ion Gas Cylinder"),
 					Spell.Buff("Hunter's Boon"),
 					Spell.Cast("Guard", on => Me.Companion,
 						ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
@@ -54,7 +53,7 @@ namespace DefaultCombat.Routines
 						new PrioritySelector(
 							Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
 							Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-							Spell.Cast("Flame Thrower", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
+							Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
 							Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Surge")),
 							Spell.Cast("Rapid Shots")
 							)),
@@ -67,7 +66,7 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Rocket Punch"),
 					Spell.Cast("Rail Shot"),
 					Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-					Spell.Cast("Flame Thrower", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
+					Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
 					Spell.Cast("Flame Burst")
 					);
 			}
@@ -80,13 +79,13 @@ namespace DefaultCombat.Routines
 				return new PrioritySelector(
 					new Decorator(ret => Targeting.ShouldAoe,
 						new PrioritySelector(
-							Spell.CastOnGround("Death from Above"),
-							Spell.Cast("Explosive Dart")
+							Spell.CastOnGround("Deadly Onslaught")
 							)),
 					new Decorator(ret => Targeting.ShouldPbaoe,
 						new PrioritySelector(
+							Spell.Cast("Shatter Slug"),
 							Spell.Cast("Firestorm", ret => Me.Level >= 57),
-							Spell.Cast("Flame Thrower", ret => Me.Level < 57),
+							Spell.Cast("Searing Wave", ret => Me.Level < 57),
 							Spell.Cast("Flame Sweep")
 							)));
 			}


### PR DESCRIPTION
Changes for 5.0:
Remove line 22 - Ion Gas Cylinder is now a passive ability, replacing Combustible Gas Cylinder.

**** Remove lines 57, 70, 89- New Active Ability: Searing Wave, a redesign of Flame Thrower.
Firestorm is the ability for ShieldTech - Searing wave is only in DPS specs ****

Update line 83 - New Active Ability: Deadly Onslaught, a Powertech exclusive redesign of Death from Above. 
Remove line 84 - Explosive Dart is now Mercenary exclusive.
Added line 88 - New Active Ability: Shatter Slug.