### PR TITLE
Update Pyrotech.cs

### DIFF
--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/Pyrotech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/Pyrotech.cs
@@ -21,7 +21,6 @@ namespace DefaultCombat.Routines
 			get
 			{
 				return new PrioritySelector(
-					Spell.Buff("Combustible Gas Cylinder"),
 					Spell.Buff("Hunter's Boon")
 					);
 			}
@@ -63,7 +62,7 @@ namespace DefaultCombat.Routines
 					//Rotation
 					Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
 					Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && !DefaultCombat.MovementDisabled),
-					Spell.Cast("Flame Thrower", ret => Me.BuffCount("Superheated Flame Thrower") == 2),
+					Spell.Cast("Searing Wave", ret => Me.BuffCount("Superheated Flame Thrower") == 2),
 					Spell.DoT("Scorch", "Scorch"),
 					Spell.DoT("Incendiary Missile", "Burning (Incendiary Missile)"),
 					Spell.Cast("Rail Shot", ret => Me.HasBuff("Charged Gauntlets")),
@@ -84,13 +83,12 @@ namespace DefaultCombat.Routines
 					new Decorator(ret => Targeting.ShouldAoe,
 						new PrioritySelector(
 							Spell.DoT("Scorch", "Scorch"),
-							Spell.CastOnGround("Death from Above"),
-							Spell.Cast("Explosive Dart")
+							Spell.CastOnGround("Deadly Onslaught")
 							)),
 					new Decorator(ret => Targeting.ShouldPbaoe,
 						new PrioritySelector(
 							Spell.DoT("Scorch", "Scorch"),
-							Spell.Cast("Flame Thrower"),
+							Spell.Cast("Searing Wave"),
 							Spell.Cast("Flame Sweep")
 							)));
 			}


### PR DESCRIPTION
Changes for 5.0:
Flame Thrower has been renamed Searing Wave, redesigned, and is now Powertech exclusive.
Powertechs receive Deadly Onslaught, an exclusive redesign of Death from Above.
Explosive Dart is now Mercenary exclusive.