### PR TITLE
* Darkness - added missing Depredating Volts - thanks SirSik

### DIFF
--- a/trunk/DefaultCombat/DefaultCombat.cs
+++ b/trunk/DefaultCombat/DefaultCombat.cs
@@ -65,7 +65,7 @@ namespace DefaultCombat
 
 		public override void Initialize()
 		{
-			Logger.Write("*** Default Combat v73***");
+			Logger.Write("*** Default Combat v74***");
 			Logger.Write("Level: " + BuddyTor.Me.Level);
 			Logger.Write("Class: " + Class);
 			Logger.Write("Advanced Class: " + BuddyTor.Me.AdvancedClass);

--- a/trunk/DefaultCombat/Routines/Advanced/Assassin/Darkness.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Assassin/Darkness.cs
@@ -73,6 +73,7 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Discharge"),
 					Spell.Cast("Thrash"),
 					Spell.Cast("Saber Strike"),
+					Spell.Cast("Depredating Volts", ret => Me.BuffCount("Harnessed Darkness") > 2),
 					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat)
 					);
 			}

--- a/trunk/DefaultCombat/Routines/Advanced/Assassin/Hatred.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Assassin/Hatred.cs
@@ -85,9 +85,9 @@ namespace DefaultCombat.Routines
 				return new Decorator(ret => Targeting.ShouldAoe,
 					new PrioritySelector(
 						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+						Spell.CastOnGround("Death Field"),
 						Spell.DoT("Discharge", "Shocked (Discharge)"),
 						Spell.DoT("Creeping Terror", "Creeping Terror"),
-						Spell.CastOnGround("Death Field"),
 						Spell.Cast("Lacerate", ret =>	Me.CurrentTarget.HasDebuff("Shocked (Discharge)") && Me.CurrentTarget.HasDebuff("Creeping Terror") &&	Me.ForcePercent >= 60 && Targeting.ShouldPbaoe)
 						));
 			}

--- a/trunk/DefaultCombat/Routines/Advanced/Commando/Gunnery.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Commando/Gunnery.cs
@@ -68,13 +68,13 @@ namespace DefaultCombat.Routines
 
 					//Rotation
 					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Boltstorm", ret => Me.HasBuff("Curtain of Fire") && Me.Level >= 57),
-					Spell.Cast("Full Auto", ret => Me.HasBuff("Curtain of Fire") && Me.Level < 57),
 					Spell.Cast("Demolition Round", ret => Me.CurrentTarget.HasDebuff("Gravity Vortex")),
 					Spell.Cast("Electro Net"),
-					Spell.Cast("Vortex Bolt"),
 					Spell.Cast("High Impact Bolt", ret => Me.BuffCount("Charged Barrel") == 5),
-					Spell.Cast("Grav Round")
+					Spell.Cast("Vortex Bolt"),
+					Spell.Cast("Boltstorm", ret => Me.HasBuff("Curtain of Fire")),
+					Spell.Cast("Grav Round"),
+					Spell.Cast("Hammer Shots")
 					);
 			}
 		}
@@ -86,11 +86,9 @@ namespace DefaultCombat.Routines
 				return new Decorator(ret => Targeting.ShouldAoe,
 					new PrioritySelector(
 						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.Cast("Sticky Grenade"),
-						Spell.Cast("Tech Override"),
-						Spell.CastOnGround("Mortar Volley"),
+						Spell.CastOnGround("Mortar Volley", ret => Me.HasBuff("Reserve Powercell")),
 						Spell.Cast("Plasma Grenade", ret => Me.ResourceStat >= 90 && Me.HasBuff("Tech Override")),
-						Spell.Cast("Pulse Cannon", ret => Me.CurrentTarget.Distance <= 1f),
+						Spell.Cast("Sticky Grenade"),
 						Spell.CastOnGround("Hail of Bolts", ret => Me.ResourceStat >= 90)
 						));
 			}

--- a/trunk/DefaultCombat/Routines/Advanced/Marauder/Annihilation.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Marauder/Annihilation.cs
@@ -30,10 +30,10 @@ namespace DefaultCombat.Routines
 			{
 				return new PrioritySelector(
 					Spell.Buff("Unleash", ret => Me.IsStunned),
+					Spell.Buff("Deadly Saber", ret => !Me.HasBuff("Deadly Saber")),
 					Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
 					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
 					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Deadly Saber", ret => !Me.HasBuff("Deadly Saber")),
 					Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
 					Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
 					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
@@ -64,16 +64,30 @@ namespace DefaultCombat.Routines
 
 					//Rotation
 					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+					Spell.Cast("Annihilate"),
 					Spell.DoT("Force Rend", "Force Rend"),
 					Spell.DoT("Rupture", "Bleeding (Rupture)"),
-					Spell.Cast("Dual Saber Throw", ret => Me.HasBuff("Pulverize")),
 					Spell.Cast("Annihilate"),
+					Spell.Cast("Force Rend"),
+					Spell.Cast("Annihilate"),
+					Spell.Cast("Dual Saber Throw", ret => Me.HasBuff("Pulverize")),
 					Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
+					Spell.Cast("Annihilate"),
 					Spell.Cast("Ravage"),
-					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9),
+					Spell.Cast("Annihilate"),
+					Spell.Cast("Force Rend"),
+					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
+					Spell.Cast("Annihilate"),	
+					Spell.Cast("Force Rend"),
 					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6),
+					Spell.Cast("Annihilate"),
+					Spell.Cast("Force Rend"),
 					Spell.Cast("Force Charge", ret => Me.ActionPoints <= 8),
-					Spell.Cast("Assault", ret => Me.ActionPoints < 9)
+					Spell.Cast("Annihilate"),
+					Spell.Cast("Force Rend"),
+					Spell.Cast("Assault", ret => Me.ActionPoints < 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
+					Spell.Cast("Annihilate"),
+					Spell.Cast("Force Rend")
 					);
 			}
 		}

--- a/trunk/DefaultCombat/Routines/Advanced/Marauder/Carnage.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Marauder/Carnage.cs
@@ -33,8 +33,9 @@ namespace DefaultCombat.Routines
 					Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
 					Spell.Buff("Force Camouflage", ret => Me.HealthPercent <= 70),
 					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 10),
+					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
 					Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
+					Spell.Buff("Bloodthirst", ret => Me.BuffCount("Fury") > 29 && Me.InCombat),
 					Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
 					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
 					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
@@ -64,17 +65,17 @@ namespace DefaultCombat.Routines
 
 					//Rotation
 					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Massacre", ret => !Me.HasBuff("Massacre")),
+					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
 					Spell.Cast("Ferocity"),
-					Spell.Cast("Gore"),
+					Spell.Cast("Devastating Blast", ret => Me.HasBuff("Ferocity")),
+					Spell.Cast("Gore", ret => Me.HasBuff("Ferocity")),
+					Spell.Cast("Vicious Throw", ret => Me.HasBuff("Ferocity")),
 					Spell.Cast("Ravage", ret => Me.HasBuff("Ferocity")),
-					Spell.Cast("Vicious Throw"),
-					Spell.Cast("Force Scream", ret => Me.HasBuff("Execute") && Me.Level < 58),
-					Spell.Cast("Devastating Blast", ret => Me.HasBuff("Execute") && Me.Level > 57),
-					Spell.Cast("Massacre"),
-					Spell.Cast("Dual Saber Throw"),
-					Spell.Cast("Battering Assault"),
-					Spell.Cast("Assault")
+					Spell.Cast("Massacre", ret => !Me.HasBuff("Massacre")),
+					Spell.Cast("Dual Saber Throw", ret => !Me.HasBuff("Ferocity")),
+					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
+					//Temp removal as a test for significant DPS loss Spell.Cast("Force Scream", ret => Me.HasBuff("Execute")),
+					Spell.Cast("Assault", ret => Me.ActionPoints <= 5 && !Me.HasBuff("Ferocity"))
 					);
 			}
 		}
@@ -86,7 +87,7 @@ namespace DefaultCombat.Routines
 				return new Decorator(ret => Targeting.ShouldPbaoe,
 					new PrioritySelector(
 						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.Cast("Smash"),
+						//Temp removal as a test for significant DPS loss Spell.Cast("Smash"),
 						Spell.Cast("Sweeping Slash")
 						));
 			}

--- a/trunk/DefaultCombat/Routines/Advanced/Operative/Concealment.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Operative/Concealment.cs
@@ -62,6 +62,11 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 					
+					//Solo Mode
+					Spell.Cast("Kolto Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Kolto Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+					
 					//Rotation
 					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 					new Decorator(ret => Me.ResourcePercent() < 60 && !AbilityManager.CanCast("Adrenaline Probe", Me),

--- a/trunk/DefaultCombat/Routines/Advanced/Sage/Balance.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sage/Balance.cs
@@ -58,6 +58,11 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 					
+					//Solo Mode
+					Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+					
 					//Rotation
 					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),

--- a/trunk/DefaultCombat/Routines/Advanced/Sage/Telekinetics.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sage/Telekinetics.cs
@@ -57,6 +57,11 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+					
+					//Solo Mode
+					Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
 					//Rotation
 					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),

--- a/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Ruffian.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Ruffian.cs
@@ -63,6 +63,11 @@ namespace DefaultCombat.Routines
 						new PrioritySelector(
 							Spell.Cast("Flurry of Bolts")
 							)),
+							
+					//Solo Mode
+					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
 					//Rotation
 					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),

--- a/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Scrapper.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Scrapper.cs
@@ -63,6 +63,11 @@ namespace DefaultCombat.Routines
 						new PrioritySelector(
 							Spell.Cast("Flurry of Bolts")
 							)),
+							
+					//Solo Mode
+					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
 					//Rotation
 					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),

--- a/trunk/DefaultCombat/Routines/Advanced/Shadow/Infiltration.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Shadow/Infiltration.cs
@@ -20,7 +20,6 @@ namespace DefaultCombat.Routines
 			{
 				return new PrioritySelector(
 					Spell.Buff("Force Valor"),
-					Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
 					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
 					);
 			}
@@ -35,7 +34,6 @@ namespace DefaultCombat.Routines
 					Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
 					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
 					Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Force Potency"),
 					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
 					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
 					);
@@ -69,13 +67,14 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Low Slash", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
 					//Rotation
+					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+					Spell.Cast("Force Potency"),
 					Spell.Cast("Force Breach", ret => Me.BuffCount("Breaching Shadows") == 3),
 					Spell.Cast("Shadow Strike", ret => Me.HasBuff("Stealth") || Me.HasBuff("Infiltration Tactics")),
 					Spell.Cast("Vaulting Slash", ret => Me.HasBuff("Stealth")),
 					Spell.Cast("Project", ret => Me.BuffCount("Circling Shadows") == 2),
 					Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Clairvoyant Strike"),
-					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat)
+					Spell.Cast("Clairvoyant Strike")
 					);
 			}
 		}

--- a/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Lightning.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Lightning.cs
@@ -57,18 +57,23 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+					
+					//Solo Mode
+					Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
 					//Rotation
 					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+					Spell.Cast("Thundering Blast"),
 					Spell.Cast("Affliction", ret => !Me.CurrentTarget.HasDebuff("Affliction")),
-					Spell.Cast("Thundering Blast", ret => Me.CurrentTarget.HasDebuff("Affliction")),
-					Spell.Cast("Lightning Flash"),
 					Spell.Cast("Crushing Darkness", ret => Me.HasBuff("Force Flash")),
+					Spell.Cast("Lightning Flash"),
+					Spell.Cast("Shock", ret => Me.CurrentTarget.HasDebuff("Crushed (Crushing Darkness)")),
+					Spell.Cast("Chain Lightning", ret => Me.HasBuff("Focal Lightning")),
+					Spell.Cast("Lightning Bolt"),
 					Spell.Cast("Force Lightning", ret => Me.HasBuff("Lightning Barrage")),
-					Spell.Cast("Chain Lightning", ret => Me.HasBuff("Lightning Storm")),
-					Spell.Cast("Lightning Bolt", ret => Me.Level >= 57),
-					Spell.Cast("Lightning Strike", ret => Me.Level < 57),
-					Spell.Cast("Shock")
+					Spell.Cast("Lightning Strike")
 					);
 			}
 		}

--- a/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Madness.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Madness.cs
@@ -62,6 +62,11 @@ namespace DefaultCombat.Routines
 					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
 					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 					
+					//Solo Mode
+					Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+					Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+					Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+					
 					//Rotation
 					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 					Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),


### PR DESCRIPTION
* Hatred - fixed Death Field (was not casting correctly)
* Carnage - added missing Bloodthirst, reorganized priority for dps increase - thanks kurfer
* Annihilation - reorganized priority for dps increase - thanks kurfer
* Lethality - added missing charge ability Holotraverse with new F Key logic
* Lethality - added better logic to Stim Boost, removed Toxic Blast, added low energy logic, simplified priority, fixed Corrosive Gernade logic - thanks BobbyT
* Lightning - changed rotation priority - thanks BobbyT
* Gunnery - reorganized priority for dps increase (went from 5,224 to 5,847)
* Infiltration - why were we using Guard on a DPS class, Force Potency is not a buff (moved to rotation)
* Finished adding missing Solo Mode classes - thanks derFalke