### PR TITLE
Bounced on my boy's dick for days

### DIFF
--- a/trunk/DefaultCombat/Core/LockSelector.cs
+++ b/trunk/DefaultCombat/Core/LockSelector.cs
@@ -6,25 +6,25 @@ using Buddy.Swtor;
 
 namespace DefaultCombat.Core
 {
-	// Use this type sparingly - nesting locks will be handled by the memory library implicitly:
-	// acquiring a single lock for the entire duration of a tick will have the same effect as acquiring 20
-	// locks by using LockSelector in various locations. More locking does therefore not guarantee "more" 
-	// consistency between the game's state. If you decide to use this type, use it in the outermost part of your logic,
-	// so that all children of the selector will run inside the lock, but if possible, refrain from replacing every
-	// single PrioritySelector with a LockSelector - it has proven to be detriment to performance for no tangible gains.
-	public class LockSelector : PrioritySelector
-	{
-		public LockSelector(params Composite[] children)
-			: base(children)
-		{
-		}
+    // Use this type sparingly - nesting locks will be handled by the memory library implicitly:
+    // acquiring a single lock for the entire duration of a tick will have the same effect as acquiring 20
+    // locks by using LockSelector in various locations. More locking does therefore not guarantee "more" 
+    // consistency between the game's state. If you decide to use this type, use it in the outermost part of your logic,
+    // so that all children of the selector will run inside the lock, but if possible, refrain from replacing every
+    // single PrioritySelector with a LockSelector - it has proven to be detriment to performance for no tangible gains.
+    public class LockSelector : PrioritySelector
+    {
+        public LockSelector(params Composite[] children)
+            : base(children)
+        {
+        }
 
-		public override RunStatus Tick(object context)
-		{
-			using (BuddyTor.Memory.AcquireFrame())
-			{
-				return base.Tick(context);
-			}
-		}
-	}
+        public override RunStatus Tick(object context)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                return base.Tick(context);
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Core/Movement.cs
+++ b/trunk/DefaultCombat/Core/Movement.cs
@@ -8,21 +8,21 @@ using Buddy.Swtor;
 
 namespace DefaultCombat.Core
 {
-	public class CombatMovement
-	{
-		public static Composite CloseDistance(float range)
-		{
-			return new Decorator(ret => !DefaultCombat.MovementDisabled && BuddyTor.Me.CurrentTarget != null,
-				new PrioritySelector(
-					new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance < range,
-						new Action(delegate
-						{
-							Navigator.MovementProvider.StopMovement();
-							return RunStatus.Failure;
-						})),
-					new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance >= range,
-						CommonBehaviors.MoveAndStop(location => BuddyTor.Me.CurrentTarget.Position, range, true)),
-					new Action(delegate { return RunStatus.Failure; })));
-		}
-	}
+    public class CombatMovement
+    {
+        public static Composite CloseDistance(float range)
+        {
+            return new Decorator(ret => !DefaultCombat.MovementDisabled && BuddyTor.Me.CurrentTarget != null,
+                new PrioritySelector(
+                    new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance < range,
+                        new Action(delegate
+                        {
+                            Navigator.MovementProvider.StopMovement();
+                            return RunStatus.Failure;
+                        })),
+                    new Decorator(ret => BuddyTor.Me.CurrentTarget.Distance >= range,
+                        CommonBehaviors.MoveAndStop(location => BuddyTor.Me.CurrentTarget.Position, range, true)),
+                    new Action(delegate { return RunStatus.Failure; })));
+        }
+    }
 }

--- a/trunk/DefaultCombat/Core/RotationFactory.cs
+++ b/trunk/DefaultCombat/Core/RotationFactory.cs
@@ -8,51 +8,51 @@ using DefaultCombat.Routines;
 
 namespace DefaultCombat.Core
 {
-	public class RotationFactory
-	{
-		public RotationBase Build(string name)
-		{
-			//Set the basic class as the rotation if char has no advanced class
-			if (BuddyTor.Me.AdvancedClass == AdvancedClass.None)
-			{
-				name = BuddyTor.Me.CharacterClass.ToString();
-			}
+    public class RotationFactory
+    {
+        public RotationBase Build(string name)
+        {
+            //Set the basic class as the rotation if char has no advanced class
+            if (BuddyTor.Me.AdvancedClass == AdvancedClass.None)
+            {
+                name = BuddyTor.Me.CharacterClass.ToString();
+            }
 
-			if (name == "Rage" && BuddyTor.Me.AdvancedClass == AdvancedClass.Marauder)
-			{
-				name = "Fury";
-			}
+            if (name == "Rage" && BuddyTor.Me.AdvancedClass == AdvancedClass.Marauder)
+            {
+                name = "Fury";
+            }
 
-			if (name == "Focus" && BuddyTor.Me.AdvancedClass == AdvancedClass.Sentinel)
-			{
-				name = "Concentration";
-			}
+            if (name == "Focus" && BuddyTor.Me.AdvancedClass == AdvancedClass.Sentinel)
+            {
+                name = "Concentration";
+            }
 
-			if (name == "DirtyFighting" && BuddyTor.Me.AdvancedClass == AdvancedClass.Scoundrel)
-			{
-				name = "Ruffian";
-			}
+            if (name == "DirtyFighting" && BuddyTor.Me.AdvancedClass == AdvancedClass.Scoundrel)
+            {
+                name = "Ruffian";
+            }
 
-			if (name == "Balance" && BuddyTor.Me.AdvancedClass == AdvancedClass.Shadow)
-			{
-				name = "Serenity";
-			}
+            if (name == "Balance" && BuddyTor.Me.AdvancedClass == AdvancedClass.Shadow)
+            {
+                name = "Serenity";
+            }
 
-			if (name == "CombatMedic" && BuddyTor.Me.AdvancedClass == AdvancedClass.Mercenary)
-			{
-				name = "Bodyguard";
-			}
+            if (name == "CombatMedic" && BuddyTor.Me.AdvancedClass == AdvancedClass.Mercenary)
+            {
+                name = "Bodyguard";
+            }
 
-			if (name == "Firebug" && BuddyTor.Me.AdvancedClass == AdvancedClass.Powertech)
-			{
-				name = "Pyrotech";
-			}
+            if (name == "Firebug" && BuddyTor.Me.AdvancedClass == AdvancedClass.Powertech)
+            {
+                name = "Pyrotech";
+            }
 
-			var ns = "DefaultCombat.Routines";
-			var assembly = Assembly.GetExecutingAssembly();
-			var type = assembly.GetType(ns + "." + name);
-			var instance = Activator.CreateInstance(type);
-			return (RotationBase) instance;
-		}
-	}
+            var ns = "DefaultCombat.Routines";
+            var assembly = Assembly.GetExecutingAssembly();
+            var type = assembly.GetType(ns + "." + name);
+            var instance = Activator.CreateInstance(type);
+            return (RotationBase)instance;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Core/Spell.cs
+++ b/trunk/DefaultCombat/Core/Spell.cs
@@ -15,254 +15,254 @@ using Action = Buddy.BehaviorTree.Action;
 
 namespace DefaultCombat.Core
 {
-	public static class Spell
-	{
-		public delegate T Selection<out T>(object context);
+    public static class Spell
+    {
+        public delegate T Selection<out T>(object context);
 
-		public delegate TorCharacter UnitSelectionDelegate(object context);
+        public delegate TorCharacter UnitSelectionDelegate(object context);
 
-		public static List<ExpiringItem> BlackListedSpells = new List<ExpiringItem>();
+        public static List<ExpiringItem> BlackListedSpells = new List<ExpiringItem>();
 
-		private static TorPlayer Me
-		{
-			get { return BuddyTor.Me; }
-		}
+        private static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
 
-		public static Composite BuffBehavior
-		{
-			get
-			{
-				return new PrioritySelector(
-					Buff("Sprint"),
-					Buff(Me.SelfBuffName()),
-					Rest.HandleRest);
-			}
-		}
+        public static Composite BuffBehavior
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Buff("Sprint"),
+                    Buff(Me.SelfBuffName()),
+                    Rest.HandleRest);
+            }
+        }
 
-		public static Composite WaitForCast()
-		{
-			return new Decorator(ret => BuddyTor.Me.IsCasting,
-				new Action(ret => RunStatus.Success));
-		}
+        public static Composite WaitForCast()
+        {
+            return new Decorator(ret => BuddyTor.Me.IsCasting,
+                new Action(ret => RunStatus.Success));
+        }
 
-		#region Buff
+        #region Buff
 
-		public static Composite Buff(string spell, Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret => (reqs == null || reqs(ret)) && !Me.HasBuff(spell),
-					Cast(spell, ret => Me, ret => true));
-		}
+        public static Composite Buff(string spell, Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret => (reqs == null || reqs(ret)) && !Me.HasBuff(spell),
+                    Cast(spell, ret => Me, ret => true));
+        }
 
-		#endregion
+        #endregion
 
-		#region Cast
+        #region Cast
 
-		public static Composite Cast(string spell, Selection<bool> reqs = null)
-		{
-			return Cast(spell, ret => Me.CurrentTarget, reqs);
-		}
+        public static Composite Cast(string spell, Selection<bool> reqs = null)
+        {
+            return Cast(spell, ret => Me.CurrentTarget, reqs);
+        }
 
-		public static Composite Cast(string spell, UnitSelectionDelegate onUnit, Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret =>
-						onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) &&
-						AbilityManager.CanCast(spell, onUnit(ret)),
-					new PrioritySelector(
-						new Action(delegate
-						{
-							//added current target health percent check
-							Logger.Write(">> Casting <<   " + spell);
-							return RunStatus.Failure;
-						}),
-						new Action(ret => AbilityManager.Cast(spell, onUnit(ret))))
-					);
-		}
+        public static Composite Cast(string spell, UnitSelectionDelegate onUnit, Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret =>
+                        onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) &&
+                        AbilityManager.CanCast(spell, onUnit(ret)),
+                    new PrioritySelector(
+                        new Action(delegate
+                        {
+                            //added current target health percent check
+                            Logger.Write(">> Casting <<   " + spell);
+                            return RunStatus.Failure;
+                        }),
+                        new Action(ret => AbilityManager.Cast(spell, onUnit(ret))))
+                    );
+        }
 
-		public static Composite CastOnGround(string spell, Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret =>
-						(reqs == null || reqs(ret)) && Me.CurrentTarget != null,
-					CastOnGround(spell, ctx => Me.CurrentTarget.Position, ctx => true));
-		}
+        public static Composite CastOnGround(string spell, Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret =>
+                        (reqs == null || reqs(ret)) && Me.CurrentTarget != null,
+                    CastOnGround(spell, ctx => Me.CurrentTarget.Position, ctx => true));
+        }
 
-		public static Composite CastOnGround(string spell, CommonBehaviors.Retrieval<Vector3> location,
-			Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret =>
-						(reqs == null || reqs(ret)) && location != null && location(ret) != Vector3.Zero &&
-						AbilityManager.CanCast(spell, BuddyTor.Me.CurrentTarget),
-					new Action(ret => AbilityManager.Cast(spell, location(ret))));
-		}
+        public static Composite CastOnGround(string spell, CommonBehaviors.Retrieval<Vector3> location,
+            Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret =>
+                        (reqs == null || reqs(ret)) && location != null && location(ret) != Vector3.Zero &&
+                        AbilityManager.CanCast(spell, BuddyTor.Me.CurrentTarget),
+                    new Action(ret => AbilityManager.Cast(spell, location(ret))));
+        }
 
-		public static Composite DoTGround(string spell, float time = 0, Selection<bool> reqs = null)
-		{
-			return DoTGround(spell, ret => BuddyTor.Me.CurrentTarget, time, reqs);
-		}
-
-
-		public static Composite DoTGround(string spell, UnitSelectionDelegate onUnit, float time, Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret => (reqs == null || reqs(ret))
-						   && onUnit != null
-						   && onUnit(ret) != null
-						   && AbilityManager.CanCast(spell, onUnit(ret))
-						   && !SpellBlackListed(spell, onUnit(ret).Guid),
-					new PrioritySelector(
-						new Action(ctx =>
-						{
-							BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
-							Logger.Write(">> Casting on Ground <<   " + spell);
-							return RunStatus.Failure;
-						}),
-						new Action(ret => AbilityManager.Cast(spell, onUnit(ret).Position))));
-		}
-
-		#endregion
-
-		#region DoT
-
-		public static Composite DoT(string spell, string debuff, float time = 0, Selection<bool> reqs = null)
-		{
-			return DoT(spell, ret => Me.CurrentTarget, debuff, time, reqs);
-		}
-
-		public static Composite DoT(string spell, UnitSelectionDelegate onUnit, string debuff, float time,
-			Selection<bool> reqs = null)
-		{
-			return
-				new Decorator(
-					ret => onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret))
-						   && !onUnit(ret).HasMyDebuff(debuff)
-						   && AbilityManager.CanCast(spell, onUnit(ret))
-						   && !SpellBlackListed(spell, onUnit(ret).Guid),
-					new PrioritySelector(
-						new Action(ctx =>
-						{
-							BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
-							Logger.Write(">> Casting <<   " + spell);
-							return RunStatus.Failure;
-						}),
-						new Action(ret => AbilityManager.Cast(spell, onUnit(ret)))));
-		}
-
-		public static float GetCastTime(string spell)
-		{
-			float castTime = 0;
-			var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CastingTime;
-			castTime += v*1000;
-			return castTime;
-		}
-
-		public static float GetCooldown(string spell)
-		{
-			float time = 0;
-			var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CooldownTime;
-			time += v*1000;
-			return time;
-		}
-
-		public static bool SpellBlackListed(string spell, float guid)
-		{
-			using (BuddyTor.Memory.AcquireFrame())
-			{
-				BlackListedSpells.RemoveAll(s => s.Item.Equals(""));
-				return BlackListedSpells.Any(s => s.Item.Equals(spell) && Math.Abs(s.TargetGuid - guid) < .01f);
-			}
-		}
-
-		#endregion
-
-		#region Heal
-
-		private static bool Target(TorCharacter onUnit)
-		{
-			onUnit.Target();
-			return true;
-		}
-
-		public static Composite Cleanse(string spell, Selection<bool> reqs = null)
-		{
-			return new Decorator(
-				ret => Targeting.DispelTarget != null && (reqs == null || reqs(ret)) && Target(Targeting.DispelTarget),
-				Cast(spell, ret => Targeting.DispelTarget, reqs));
-		}
+        public static Composite DoTGround(string spell, float time = 0, Selection<bool> reqs = null)
+        {
+            return DoTGround(spell, ret => BuddyTor.Me.CurrentTarget, time, reqs);
+        }
 
 
-		public static Composite Heal(string spell, int hp = 100, Selection<bool> reqs = null)
-		{
-			return Heal(spell, onUnit => Targeting.HealTarget, hp, reqs);
-		}
+        public static Composite DoTGround(string spell, UnitSelectionDelegate onUnit, float time, Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret => (reqs == null || reqs(ret))
+                           && onUnit != null
+                           && onUnit(ret) != null
+                           && AbilityManager.CanCast(spell, onUnit(ret))
+                           && !SpellBlackListed(spell, onUnit(ret).Guid),
+                    new PrioritySelector(
+                        new Action(ctx =>
+                        {
+                            BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
+                            Logger.Write(">> Casting on Ground <<   " + spell);
+                            return RunStatus.Failure;
+                        }),
+                        new Action(ret => AbilityManager.Cast(spell, onUnit(ret).Position))));
+        }
 
-		public static Composite Heal(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
-		{
-			return new Decorator(
-				ret =>
-					onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && onUnit(ret).HealthPercent <= hp &&
-					Target(onUnit(ret)),
-				Cast(spell, onUnit, reqs));
-		}
+        #endregion
 
-		public static Composite HealAoe(string spell, Selection<bool> reqs = null)
-		{
-			return new Decorator(
-				ret => (reqs == null || reqs(ret)) && Targeting.ShouldAoeHeal && Targeting.AoeHealTarget != null,
-				Cast(spell, onUnit => Targeting.AoeHealTarget, reqs));
-		}
+        #region DoT
 
-		public static Composite HoT(string spell, int hp = 100, Selection<bool> reqs = null)
-		{
-			return new Decorator(ret => Targeting.HealTarget != null,
-				HoT(spell, onUnit => Targeting.HealTarget, hp, reqs));
-		}
+        public static Composite DoT(string spell, string debuff, float time = 0, Selection<bool> reqs = null)
+        {
+            return DoT(spell, ret => Me.CurrentTarget, debuff, time, reqs);
+        }
 
-		public static Composite HoT(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
-		{
-			return new Decorator(
-				ret =>
-					onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && !onUnit(ret).HasMyBuff(spell) &&
-					onUnit(ret).HealthPercent <= hp,
-				Cast(spell, onUnit, reqs));
-		}
+        public static Composite DoT(string spell, UnitSelectionDelegate onUnit, string debuff, float time,
+            Selection<bool> reqs = null)
+        {
+            return
+                new Decorator(
+                    ret => onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret))
+                           && !onUnit(ret).HasMyDebuff(debuff)
+                           && AbilityManager.CanCast(spell, onUnit(ret))
+                           && !SpellBlackListed(spell, onUnit(ret).Guid),
+                    new PrioritySelector(
+                        new Action(ctx =>
+                        {
+                            BlackListedSpells.Add(new ExpiringItem(spell, GetCooldown(spell) + 25 + time, onUnit(ctx).Guid));
+                            Logger.Write(">> Casting <<   " + spell);
+                            return RunStatus.Failure;
+                        }),
+                        new Action(ret => AbilityManager.Cast(spell, onUnit(ret)))));
+        }
 
-		public static Composite HealGround(string spell, CanRunDecoratorDelegate reqs = null)
-		{
-			return new Decorator(
-				ret =>
-					Targeting.AoeHealPoint != Vector3.Zero && (reqs == null || reqs(ret)) &&
-					Targeting.ShouldAoeHeal,
-				CastOnGround(spell, ret => Targeting.AoeHealPoint, ret => true));
-		}
+        public static float GetCastTime(string spell)
+        {
+            float castTime = 0;
+            var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CastingTime;
+            castTime += v * 1000;
+            return castTime;
+        }
 
-		#endregion
-	}
+        public static float GetCooldown(string spell)
+        {
+            float time = 0;
+            var v = AbilityManager.KnownAbilities.FirstOrDefault(a => a.Name.Contains(spell)).CooldownTime;
+            time += v * 1000;
+            return time;
+        }
 
-	public class ExpiringItem
-	{
-		public string Item;
-		public ulong TargetGuid;
+        public static bool SpellBlackListed(string spell, float guid)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                BlackListedSpells.RemoveAll(s => s.Item.Equals(""));
+                return BlackListedSpells.Any(s => s.Item.Equals(spell) && Math.Abs(s.TargetGuid - guid) < .01f);
+            }
+        }
 
-		public ExpiringItem(string str, float milisecs, ulong g)
-		{
-			Item = str;
-			var t = new Timer(milisecs);
-			TargetGuid = g;
-			t.Elapsed += Elapsed_Event;
-			t.Start();
-		}
+        #endregion
 
-		private void Elapsed_Event(object sender, ElapsedEventArgs e)
-		{
-			Item = "";
-		}
-	}
+        #region Heal
+
+        private static bool Target(TorCharacter onUnit)
+        {
+            onUnit.Target();
+            return true;
+        }
+
+        public static Composite Cleanse(string spell, Selection<bool> reqs = null)
+        {
+            return new Decorator(
+                ret => Targeting.DispelTarget != null && (reqs == null || reqs(ret)) && Target(Targeting.DispelTarget),
+                Cast(spell, ret => Targeting.DispelTarget, reqs));
+        }
+
+
+        public static Composite Heal(string spell, int hp = 100, Selection<bool> reqs = null)
+        {
+            return Heal(spell, onUnit => Targeting.HealTarget, hp, reqs);
+        }
+
+        public static Composite Heal(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
+        {
+            return new Decorator(
+                ret =>
+                    onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && onUnit(ret).HealthPercent <= hp &&
+                    Target(onUnit(ret)),
+                Cast(spell, onUnit, reqs));
+        }
+
+        public static Composite HealAoe(string spell, Selection<bool> reqs = null)
+        {
+            return new Decorator(
+                ret => (reqs == null || reqs(ret)) && Targeting.ShouldAoeHeal && Targeting.AoeHealTarget != null,
+                Cast(spell, onUnit => Targeting.AoeHealTarget, reqs));
+        }
+
+        public static Composite HoT(string spell, int hp = 100, Selection<bool> reqs = null)
+        {
+            return new Decorator(ret => Targeting.HealTarget != null,
+                HoT(spell, onUnit => Targeting.HealTarget, hp, reqs));
+        }
+
+        public static Composite HoT(string spell, UnitSelectionDelegate onUnit, int hp = 100, Selection<bool> reqs = null)
+        {
+            return new Decorator(
+                ret =>
+                    onUnit != null && onUnit(ret) != null && (reqs == null || reqs(ret)) && !onUnit(ret).HasMyBuff(spell) &&
+                    onUnit(ret).HealthPercent <= hp,
+                Cast(spell, onUnit, reqs));
+        }
+
+        public static Composite HealGround(string spell, CanRunDecoratorDelegate reqs = null)
+        {
+            return new Decorator(
+                ret =>
+                    Targeting.AoeHealPoint != Vector3.Zero && (reqs == null || reqs(ret)) &&
+                    Targeting.ShouldAoeHeal,
+                CastOnGround(spell, ret => Targeting.AoeHealPoint, ret => true));
+        }
+
+        #endregion
+    }
+
+    public class ExpiringItem
+    {
+        public string Item;
+        public ulong TargetGuid;
+
+        public ExpiringItem(string str, float milisecs, ulong g)
+        {
+            Item = str;
+            var t = new Timer(milisecs);
+            TargetGuid = g;
+            t.Elapsed += Elapsed_Event;
+            t.Start();
+        }
+
+        private void Elapsed_Event(object sender, ElapsedEventArgs e)
+        {
+            Item = "";
+        }
+    }
 }

--- a/trunk/DefaultCombat/Core/Targeting.cs
+++ b/trunk/DefaultCombat/Core/Targeting.cs
@@ -11,287 +11,287 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Core
 {
-	public static class Targeting
-	{
-		private const int AoedpsCountNeeded = 3;
-		private const int AoeHealCountNeeded = 2;
+    public static class Targeting
+    {
+        private const int AoedpsCountNeeded = 3;
+        private const int AoeHealCountNeeded = 2;
 
-		//Settings for making target queries
-		private const int MaxHealth = Health.Max;
-		private const float HealingDistance = Distance.Ranged;
-		private const float AoeHealDist = Distance.HealAoe;
-		private const int AoeHealHp = Health.High;
-		//Collections
-		public static List<TorCharacter> HealCandidates;
-		public static List<TorCharacter> Tanks;
-		public static List<Vector3> HealCandidatePoints;
-		public static List<TorCharacter> Enemies = new List<TorCharacter>();
-		public static List<Vector3> EnemyPoints = new List<Vector3>();
+        //Settings for making target queries
+        private const int MaxHealth = Health.Max;
+        private const float HealingDistance = Distance.Ranged;
+        private const float AoeHealDist = Distance.HealAoe;
+        private const int AoeHealHp = Health.High;
+        //Collections
+        public static List<TorCharacter> HealCandidates;
+        public static List<TorCharacter> Tanks;
+        public static List<Vector3> HealCandidatePoints;
+        public static List<TorCharacter> Enemies = new List<TorCharacter>();
+        public static List<Vector3> EnemyPoints = new List<Vector3>();
 
-		//Static Points and People
-		public static string TankName = "";
-		public static string TankNameStart;
-		public static string TankNameCheck;
-		public static TorCharacter Tank;
-		public static TorCharacter HealTarget;
-		public static TorCharacter AoeHealTarget;
-		public static TorCharacter AoeDpsTarget;
-		public static TorCharacter DispelTarget;
+        //Static Points and People
+        public static string TankName = "";
+        public static string TankNameStart;
+        public static string TankNameCheck;
+        public static TorCharacter Tank;
+        public static TorCharacter HealTarget;
+        public static TorCharacter AoeHealTarget;
+        public static TorCharacter AoeDpsTarget;
+        public static TorCharacter DispelTarget;
 
-		public static Vector3 AoeDpsPoint = Vector3.Zero;
+        public static Vector3 AoeDpsPoint = Vector3.Zero;
 
-		//Counts
-		public static int AoeHealCount;
-		public static int AoeDpsCount;
-		public static int AoePeanutButterCount;
-		private static int _aoepbCountNeeded = 3;
-		public static bool ShouldAoeHeal;
-		public static bool ShouldAoe;
-		public static bool ShouldPbaoe;
-		public static Vector3 AoeHealPoint = Vector3.Zero;
-
-
-		//Caching shit
-		public static int cacheCount = 75;
-		public static int maxCacheCount = 2;
-		public static List<TorCharacter> Objects;
-		public static List<TorCharacter> objects;
-
-		private static TorPlayer Me
-		{
-			get { return BuddyTor.Me; }
-		}
-
-		//Determine if we should use the tank's target.
-		private static bool UseTankTarget
-		{
-			get
-			{
-				return Me.CurrentTarget == null && Tank != null && Tank.Guid != Me.Guid && Tank.InCombat &&
-					   Tank.CurrentTarget != null;
-			}
-		}
-
-		public static Composite ScanTargets
-		{
-			get
-			{
-				return new Action(delegate
-				{
-					//increment shit!
-					cacheCount++;
-
-					//Reset counts
-					AoeHealCount = 0;
-					AoeDpsCount = 0;
-					AoePeanutButterCount = 0;
-					//Reset Targets
-					//     Tank = null;
-					HealTarget = null;
-					AoeHealTarget = null;
-					AoeHealPoint = Vector3.Zero;
-					DispelTarget = null;
+        //Counts
+        public static int AoeHealCount;
+        public static int AoeDpsCount;
+        public static int AoePeanutButterCount;
+        private static readonly int s_aoepbCountNeeded = 3;
+        public static bool ShouldAoeHeal;
+        public static bool ShouldAoe;
+        public static bool ShouldPbaoe;
+        public static Vector3 AoeHealPoint = Vector3.Zero;
 
 
-					//Reset Lists and shit
-					HealCandidates = new List<TorCharacter>();
-					HealCandidatePoints = new List<Vector3>();
-					EnemyPoints = new List<Vector3>();
-					Tanks = new List<TorCharacter>();
-					ShouldAoeHeal = false;
-					var objects = GetTorCharacters();
+        //Caching shit
+        public static int cacheCount = 75;
+        public static int maxCacheCount = 2;
+        public static List<TorCharacter> Objects;
+        public static List<TorCharacter> objects;
+
+        private static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
+
+        //Determine if we should use the tank's target.
+        private static bool UseTankTarget
+        {
+            get
+            {
+                return Me.CurrentTarget == null && Tank != null && Tank.Guid != Me.Guid && Tank.InCombat &&
+                       Tank.CurrentTarget != null;
+            }
+        }
+
+        public static Composite ScanTargets
+        {
+            get
+            {
+                return new Action(delegate
+                {
+                    //increment shit!
+                    cacheCount++;
+
+                    //Reset counts
+                    AoeHealCount = 0;
+                    AoeDpsCount = 0;
+                    AoePeanutButterCount = 0;
+                    //Reset Targets
+                    //     Tank = null;
+                    HealTarget = null;
+                    AoeHealTarget = null;
+                    AoeHealPoint = Vector3.Zero;
+                    DispelTarget = null;
 
 
-					//update the cache when we feel like it
-					if (cacheCount >= maxCacheCount)
-						updateObjects();
-
-					if (DefaultCombat.IsHealer)
-					{
-						foreach (var p in Objects)
-						{
-							//Doing this shit early
-
-							//    Logger.Write(p.Name);
-							if (Tank != null && Tank == p)
-								Tank = p;
-
-							if (Tank == null && p.Name == TankName && !p.IsDead)
-								Tank = p;
-
-							// Got a Focus Tank?
-							if (Tank == null && Me.FocusTargetIsActive && p.Guid == Me.FocusTargetID && !p.IsDead)
-								Tank = p;
-
-							if (p.IsPartyRoleTank())
-								Tanks.Add(p);
-
-							// Damn couldnt find a tank ima be the boss!
-
-							if (Tank == null && Me.Companion != null)
-								Tank = Me.Companion;
-
-							if (Tank == null && Me.Companion == null)
-								Tank = Me;
-
-							//Check for HealTarget
-							if (p.Health <= p.statHealth && !p.IsDead)
-							{
-								if (HealTarget == null || p.Health < HealTarget.statHealth)
-									HealTarget = p;
-
-								//Add to candidtates list
-								HealCandidates.Add(p);
-								HealCandidatePoints.Add(p.Position);
-
-								//increment our AOEHealCount
-								if (p.Health <= AoeHealHp)
-									AoeHealCount++;
-							}
-
-							if (p.NeedsCleanse())
-							{
-								if (DispelTarget != null && p.Health < DispelTarget.statHealth)
-									DispelTarget = p;
-
-								if (DispelTarget == null)
-									DispelTarget = p;
-							}
-						}
+                    //Reset Lists and shit
+                    HealCandidates = new List<TorCharacter>();
+                    HealCandidatePoints = new List<Vector3>();
+                    EnemyPoints = new List<Vector3>();
+                    Tanks = new List<TorCharacter>();
+                    ShouldAoeHeal = false;
+                    var objects = GetTorCharacters();
 
 
-						//We have checked everyone out, lets set AOE stuff
-						if (AoeHealCount >= AoeHealCountNeeded)
-						{
-							ShouldAoeHeal = true;
-							//AOEHealTarget
-							AoeHealTarget = AoeHealLocation(AoeHealDist);
+                    //update the cache when we feel like it
+                    if (cacheCount >= maxCacheCount)
+                        updateObjects();
 
-							//AOEHealPoint
-							if (AoeHealTarget != null)
-								AoeHealPoint = AoeHealLocation(AoeHealTarget);
-						}
-					}
+                    if (DefaultCombat.IsHealer)
+                    {
+                        foreach (var p in Objects)
+                        {
+                            //Doing this shit early
 
-					foreach (var c in objects)
-					{
-						//Dps
-						if (c.IsValidTarget())
-						{
-							//Enemies.Add(c);
-							EnemyPoints.Add(c.Position);
-						}
+                            //    Logger.Write(p.Name);
+                            if (Tank != null && Tank == p)
+                                Tank = p;
 
-						if (Me.CurrentTarget != null)
-							ShouldAoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.CurrentTarget.Position);
+                            if (Tank == null && p.Name == TankName && !p.IsDead)
+                                Tank = p;
 
-						ShouldPbaoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.Position);
-					}
+                            // Got a Focus Tank?
+                            if (Tank == null && Me.FocusTargetIsActive && p.Guid == Me.FocusTargetID && !p.IsDead)
+                                Tank = p;
+
+                            if (p.IsPartyRoleTank())
+                                Tanks.Add(p);
+
+                            // Damn couldnt find a tank ima be the boss!
+
+                            if (Tank == null && Me.Companion != null)
+                                Tank = Me.Companion;
+
+                            if (Tank == null && Me.Companion == null)
+                                Tank = Me;
+
+                            //Check for HealTarget
+                            if (p.Health <= p.statHealth && !p.IsDead)
+                            {
+                                if (HealTarget == null || p.Health < HealTarget.statHealth)
+                                    HealTarget = p;
+
+                                //Add to candidtates list
+                                HealCandidates.Add(p);
+                                HealCandidatePoints.Add(p.Position);
+
+                                //increment our AOEHealCount
+                                if (p.Health <= AoeHealHp)
+                                    AoeHealCount++;
+                            }
+
+                            if (p.NeedsCleanse())
+                            {
+                                if (DispelTarget != null && p.Health < DispelTarget.statHealth)
+                                    DispelTarget = p;
+
+                                if (DispelTarget == null)
+                                    DispelTarget = p;
+                            }
+                        }
 
 
-					return RunStatus.Failure;
-				});
-			}
-		}
+                        //We have checked everyone out, lets set AOE stuff
+                        if (AoeHealCount >= AoeHealCountNeeded)
+                        {
+                            ShouldAoeHeal = true;
+                            //AOEHealTarget
+                            AoeHealTarget = AoeHealLocation(AoeHealDist);
 
-		public static void SetTank()
-		{
-			TankNameStart = Me.CurrentTarget.ToString();
-			TankNameCheck = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
+                            //AOEHealPoint
+                            if (AoeHealTarget != null)
+                                AoeHealPoint = AoeHealLocation(AoeHealTarget);
+                        }
+                    }
 
-			if (Me.CurrentTarget != null && Me.CurrentTarget.IsFriendly && !TankName.Equals(TankNameCheck))
-			{
-				TankName = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
-				Logger.Write("Tank set to : " + TankName);
-				Tank = null;
-			}
-			else
-			{
-				TankName = "";
-				Tank = null;
-				Logger.Write("Cleared Tank");
-			}
-		}
+                    foreach (var c in objects)
+                    {
+                        //Dps
+                        if (c.IsValidTarget())
+                        {
+                            //Enemies.Add(c);
+                            EnemyPoints.Add(c.Position);
+                        }
 
-		private static void updateObjects()
-		{
-			if (DefaultCombat.IsHealer)
-			{
-				Objects = Me.PartyMembers(false).ToList().FindAll(p =>
-					!p.IsDead
-					&& p.DistanceSqr < HealingDistance*HealingDistance
-					&& p.InLineOfSight);
+                        if (Me.CurrentTarget != null)
+                            ShouldAoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.CurrentTarget.Position);
 
-				if (!Objects.Contains(Me))
-					Objects.Add(Me);
+                        ShouldPbaoe = CheckDpsAoe(AoedpsCountNeeded, Distance.MeleeAoE, Me.Position);
+                    }
 
-				if (Me.Companion != null && !Objects.Contains(Me.Companion))
-					Objects.Add(Me.Companion);
-			}
 
-			//Reset dat count
-			cacheCount = 0;
-		}
+                    return RunStatus.Failure;
+                });
+            }
+        }
 
-		public static List<TorCharacter> GetTorCharacters()
-		{
-			using (BuddyTor.Memory.AcquireFrame())
-			{
-				//List<TorCharacter> objects = ObjectManager.GetObjects<TorCharacter>().ToList();
+        public static void SetTank()
+        {
+            TankNameStart = Me.CurrentTarget.ToString();
+            TankNameCheck = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
 
-				/*
+            if (Me.CurrentTarget != null && Me.CurrentTarget.IsFriendly && !TankName.Equals(TankNameCheck))
+            {
+                TankName = TankNameStart.Substring(0, TankNameStart.IndexOf(','));
+                Logger.Write("Tank set to : " + TankName);
+                Tank = null;
+            }
+            else
+            {
+                TankName = "";
+                Tank = null;
+                Logger.Write("Cleared Tank");
+            }
+        }
+
+        private static void updateObjects()
+        {
+            if (DefaultCombat.IsHealer)
+            {
+                Objects = Me.PartyMembers(false).ToList().FindAll(p =>
+                    !p.IsDead
+                    && p.DistanceSqr < HealingDistance * HealingDistance
+                    && p.InLineOfSight);
+
+                if (!Objects.Contains(Me))
+                    Objects.Add(Me);
+
+                if (Me.Companion != null && !Objects.Contains(Me.Companion))
+                    Objects.Add(Me.Companion);
+            }
+
+            //Reset dat count
+            cacheCount = 0;
+        }
+
+        public static List<TorCharacter> GetTorCharacters()
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                //List<TorCharacter> objects = ObjectManager.GetObjects<TorCharacter>().ToList();
+
+                /*
                 if (Me.Companion != null)
                     objects.Add(Me.Companion);
                 */
-				var npcs = ObjectManager.GetObjects<TorNpc>();
-				var objects = npcs.Cast<TorCharacter>().ToList();
+                var npcs = ObjectManager.GetObjects<TorNpc>();
+                var objects = npcs.Cast<TorCharacter>().ToList();
 
-				return objects;
-			}
-		}
+                return objects;
+            }
+        }
 
-		private static Vector3 AoeHealLocation(TorCharacter p)
-		{
-			return p != null ? p.Position : Vector3.Zero;
-		}
+        private static Vector3 AoeHealLocation(TorCharacter p)
+        {
+            return p != null ? p.Position : Vector3.Zero;
+        }
 
-		private static TorCharacter AoeHealLocation(float dist)
-		{
-			using (BuddyTor.Memory.AcquireFrame())
-			{
-				TorCharacter pt = Me;
+        private static TorCharacter AoeHealLocation(float dist)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                TorCharacter pt = Me;
 
-				if (Tank != null)
-					pt = Tank;
+                if (Tank != null)
+                    pt = Tank;
 
-				var currentPtCount = PointsAroundPoint(pt.Position, HealCandidatePoints, dist);
-				var tempCount = 0;
-				foreach (var p in HealCandidates)
-				{
-					tempCount = PointsAroundPoint(p.Position, HealCandidatePoints, dist);
-					if (p.Guid != Me.Guid && tempCount > currentPtCount)
-					{
-						pt = p;
-						currentPtCount = tempCount;
-					}
-				}
+                var currentPtCount = PointsAroundPoint(pt.Position, HealCandidatePoints, dist);
+                var tempCount = 0;
+                foreach (var p in HealCandidates)
+                {
+                    tempCount = PointsAroundPoint(p.Position, HealCandidatePoints, dist);
+                    if (p.Guid != Me.Guid && tempCount > currentPtCount)
+                    {
+                        pt = p;
+                        currentPtCount = tempCount;
+                    }
+                }
 
-				return tempCount >= AoeHealCountNeeded ? pt : null;
-			}
-		}
+                return tempCount >= AoeHealCountNeeded ? pt : null;
+            }
+        }
 
-		public static bool CheckDpsAoe(int minMobs, float distance, Vector3 center)
-		{
-			return PointsAroundPoint(center, EnemyPoints, distance) >= minMobs;
-		}
+        public static bool CheckDpsAoe(int minMobs, float distance, Vector3 center)
+        {
+            return PointsAroundPoint(center, EnemyPoints, distance) >= minMobs;
+        }
 
-		private static int PointsAroundPoint(Vector3 pt, List<Vector3> l, float dist)
-		{
-			using (BuddyTor.Memory.AcquireFrame())
-			{
-				var maxDistance = dist*dist;
-				return l.Count(p => p.DistanceSqr(pt) <= maxDistance);
-			}
-		}
-	}
+        private static int PointsAroundPoint(Vector3 pt, List<Vector3> l, float dist)
+        {
+            using (BuddyTor.Memory.AcquireFrame())
+            {
+                var maxDistance = dist * dist;
+                return l.Count(p => p.DistanceSqr(pt) <= maxDistance);
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/DefaultCombat.cs
+++ b/trunk/DefaultCombat/DefaultCombat.cs
@@ -11,102 +11,102 @@ using Targeting = DefaultCombat.Core.Targeting;
 
 namespace DefaultCombat
 {
-	public class DefaultCombat : CombatRoutine
-	{
-		public static bool IsHealer;
-		private static readonly InventoryManagerItem MedPack = new InventoryManagerItem("Medpac", 90);
-		private Composite _combat;
-		private Composite _ooc;
-		private Composite _pull;
+    public class DefaultCombat : CombatRoutine
+    {
+        public static bool IsHealer;
+        private static readonly InventoryManagerItem s_medPack = new InventoryManagerItem("Medpac", 90);
+        private Composite _combat;
+        private Composite _ooc;
+        private Composite _pull;
 
-		public static bool MovementDisabled
-		{
-			get { return BotMain.CurrentBot.Name == "Combat Bot"; }
-		}
+        public static bool MovementDisabled
+        {
+            get { return BotMain.CurrentBot.Name == "Combat Bot"; }
+        }
 
-		public static bool Grind
-		{
-			get { return BotMain.CurrentBot.Name == "Grind Bot"; }
-		}
+        public static bool Grind
+        {
+            get { return BotMain.CurrentBot.Name == "Grind Bot"; }
+        }
 
-		public override string Name
-		{
-			get { return "DefaultCombat"; }
-		}
+        public override string Name
+        {
+            get { return "DefaultCombat"; }
+        }
 
-		public override Window ConfigWindow
-		{
-			get { return null; }
-		}
+        public override Window ConfigWindow
+        {
+            get { return null; }
+        }
 
-		public override CharacterClass Class
-		{
-			get { return BuddyTor.Me.Class; }
-		}
+        public override CharacterClass Class
+        {
+            get { return BuddyTor.Me.Class; }
+        }
 
-		public override Composite OutOfCombat
-		{
-			get { return _ooc; }
-		}
+        public override Composite OutOfCombat
+        {
+            get { return _ooc; }
+        }
 
-		public override Composite Pull
-		{
-			get { return _pull; }
-		}
+        public override Composite Pull
+        {
+            get { return _pull; }
+        }
 
-		public override Composite Combat
-		{
-			get { return _combat; }
-		}
+        public override Composite Combat
+        {
+            get { return _combat; }
+        }
 
-		public override void Dispose()
-		{
-		}
+        public override void Dispose()
+        {
+        }
 
-		public override void Initialize()
-		{
-			Logger.Write("*** Default Combat v77***");
-			Logger.Write("Level: " + BuddyTor.Me.Level);
-			Logger.Write("Class: " + Class);
-			Logger.Write("Advanced Class: " + BuddyTor.Me.AdvancedClass);
-			Logger.Write("Discipline: " + BuddyTor.Me.Discipline);
+        public override void Initialize()
+        {
+            Logger.Write("*** Default Combat v78***");
+            Logger.Write("Level: " + BuddyTor.Me.Level);
+            Logger.Write("Class: " + Class);
+            Logger.Write("Advanced Class: " + BuddyTor.Me.AdvancedClass);
+            Logger.Write("Discipline: " + BuddyTor.Me.Discipline);
 
-			var f = new RotationFactory();
-			var b = f.Build(BuddyTor.Me.Discipline.ToString());
+            var f = new RotationFactory();
+            var b = f.Build(BuddyTor.Me.Discipline.ToString());
 
-			CombatHotkeys.Initialize();
+            CombatHotkeys.Initialize();
 
-			if (b == null)
-				b = f.Build(BuddyTor.Me.CharacterClass.ToString());
+            if (b == null)
+                b = f.Build(BuddyTor.Me.CharacterClass.ToString());
 
-			Logger.Write("Rotation Selected : " + b.Name);
+            Logger.Write("Rotation Selected : " + b.Name);
 
-			if (BuddyTor.Me.IsHealer())
-			{
-				IsHealer = true;
-				Logger.Write("Healing Enabled");
-			}
+            if (BuddyTor.Me.IsHealer())
+            {
+                IsHealer = true;
+                Logger.Write("Healing Enabled");
+            }
 
-			_ooc = new Decorator(ret => !BuddyTor.Me.IsDead && !BuddyTor.Me.IsMounted && !CombatHotkeys.PauseRotation,
-				new PrioritySelector(
-					Spell.Buff(BuddyTor.Me.SelfBuffName()),
-					b.Buffs,
-					Rest.HandleRest,
-					Scavenge.ScavengeCorpse
-					));
+            _ooc = new Decorator(ret => !BuddyTor.Me.IsDead && !BuddyTor.Me.IsMounted && !CombatHotkeys.PauseRotation,
+                new PrioritySelector(
+                    Spell.Buff(BuddyTor.Me.SelfBuffName()),
+                    b.Buffs,
+                    Rest.HandleRest,
+                    Scavenge.ScavengeCorpse
+                    ));
 
-			_combat = new Decorator(ret => !CombatHotkeys.PauseRotation,
-				new PrioritySelector(
-					Spell.WaitForCast(),
-					MedPack.UseItem(ret => BuddyTor.Me.HealthPercent <= 30),
-					Targeting.ScanTargets,
-					b.Cooldowns,
-					new Decorator(ret => CombatHotkeys.EnableAoe, b.AreaOfEffect),
-					b.SingleTarget));
+            _combat = new Decorator(ret => !CombatHotkeys.PauseRotation,
+                new PrioritySelector(
+                    Spell.WaitForCast(),
+                    s_medPack.UseItem(ret => BuddyTor.Me.HealthPercent <= 30),
+                    Targeting.ScanTargets,
+                    b.Cooldowns,
+                    new Decorator(ret => CombatHotkeys.EnableAoe, b.AreaOfEffect),
+                    b.SingleTarget));
 
-			_pull = new Decorator(ret => !CombatHotkeys.PauseRotation && !MovementDisabled || IsHealer && !Grind,
-				_combat
-				);
-		}
-	}
+            _pull = new Decorator(ret => !CombatHotkeys.PauseRotation && !MovementDisabled || IsHealer && !Grind,
+                _combat
+                );
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/CombatHotkeys.cs
+++ b/trunk/DefaultCombat/Helpers/CombatHotkeys.cs
@@ -7,131 +7,130 @@ using DefaultCombat.Core;
 
 namespace DefaultCombat.Helpers
 {
-	public static class CombatHotkeys
-	{
-		public static bool EnableAoe;
-		public static bool PauseRotation;
-		public static bool EnableInterrupts;
-		public static bool EnableCharge;
-		public static bool EnableSolo;
-		public static bool EnableHK55;
+    public static class CombatHotkeys
+    {
+        public static bool EnableAoe;
+        public static bool PauseRotation;
+        public static bool EnableInterrupts;
+        public static bool EnableCharge;
+        public static bool EnableSolo;
+        public static bool EnableHK55;
 
-		public static void Initialize()
-		{
-			EnableAoe = true;
-			PauseRotation = false;
-			EnableInterrupts = true; 
-			EnableCharge = true;
-			EnableSolo = false;
-			EnableHK55 = false;
-			
-			//F9 and F10 are reservered for internal commands
+        public static void Initialize()
+        {
+            EnableAoe = true;
+            PauseRotation = false;
+            EnableInterrupts = true;
+            EnableCharge = true;
+            EnableSolo = false;
+            EnableHK55 = false;
 
-			Hotkeys.RegisterHotkey("Toggle HK55 (F4)", ChangeHK55, Keys.F4);
-			Logger.Write("[Hot Key][F4] Toggle HK55");
-			
-			Hotkeys.RegisterHotkey("Toggle Interrupts (F5)", ChangeInterrupts, Keys.F5);
-			Logger.Write("[Hot Key][F5] Toggle Interrupts");
+            //F9 and F10 are reservered for internal commands
 
-			Hotkeys.RegisterHotkey("Toggle Charge (F6)", ChangeCharge, Keys.F6);
-			Logger.Write("[Hot Key][F6] Toggle Charge");
-			
-			Hotkeys.RegisterHotkey("Toggle AOE (F7)", ChangeAoe, Keys.F7);
-			Logger.Write("[Hot Key][F7] Toggle AOE");
+            Hotkeys.RegisterHotkey("Toggle HK55 (F4)", ChangeHK55, Keys.F4);
+            Logger.Write("[Hot Key][F4] Toggle HK55");
 
-			Hotkeys.RegisterHotkey("Pause Rotation (F8)", ChangePause, Keys.F8);
-			Logger.Write("[Hot Key][F8] Pause Rotation");
-			
-			Hotkeys.RegisterHotkey("Toggle Solo (F11)", ChangeSolo, Keys.F11);
-			Logger.Write("[Hot Key][F11] Toggle Solo Mode");
+            Hotkeys.RegisterHotkey("Toggle Interrupts (F5)", ChangeInterrupts, Keys.F5);
+            Logger.Write("[Hot Key][F5] Toggle Interrupts");
 
-			Hotkeys.RegisterHotkey("Set Tank (F12)", Targeting.SetTank, Keys.F12);
-			Logger.Write("[Hot Key][F12] Set Tank");
-			
-		}
+            Hotkeys.RegisterHotkey("Toggle Charge (F6)", ChangeCharge, Keys.F6);
+            Logger.Write("[Hot Key][F6] Toggle Charge");
 
-		private static void ChangeAoe()
-		{
-			if (EnableAoe)
-			{
-				Logger.Write("AOE Disabled");
-				EnableAoe = false;
-			}
-			else
-			{
-				Logger.Write("AOE Enabled");
-				EnableAoe = true;
-			}
-		}
+            Hotkeys.RegisterHotkey("Toggle AOE (F7)", ChangeAoe, Keys.F7);
+            Logger.Write("[Hot Key][F7] Toggle AOE");
 
-		private static void ChangePause()
-		{
-			if (PauseRotation)
-			{
-				Logger.Write("Rotation Resumed");
-				PauseRotation = false;
-			}
-			else
-			{
-				Logger.Write("Rotation Paused");
-				PauseRotation = true;
-			}
-		}
-		
-		private static void ChangeCharge()
-		{
-			if (EnableCharge)
-			{
-				Logger.Write("Charge Disabled");
-				EnableCharge = false;
-			}
-			else
-			{
-				Logger.Write("Charge Enabled");
-				EnableCharge = true;
-			}
-		}
+            Hotkeys.RegisterHotkey("Pause Rotation (F8)", ChangePause, Keys.F8);
+            Logger.Write("[Hot Key][F8] Pause Rotation");
 
-		private static void ChangeInterrupts()
-		{
-			if (EnableInterrupts)
-			{
-				Logger.Write("Interrupts Disabled");
-				EnableInterrupts = false;
-			}
-			else
-			{
-				Logger.Write("Interrupts Enabled");
-				EnableInterrupts = true;
-			}
-		}
-		
-		private static void ChangeSolo()
-		{
-			if (EnableSolo)
-			{
-				Logger.Write("Solo Mode Disabled");
-				EnableSolo = false;
-			}
-			else
-			{
-				Logger.Write("Solo Mode Enabled");
-				EnableSolo = true;
-			}
-		}
+            Hotkeys.RegisterHotkey("Toggle Solo (F11)", ChangeSolo, Keys.F11);
+            Logger.Write("[Hot Key][F11] Toggle Solo Mode");
 
-		private static void ChangeHK55()
-		{
-			if (EnableHK55)
-			{
-				Logger.Write("HK-55 Mode Disabled");
-				EnableHK55 = false;
-			}
-			else
-			{
-				Logger.Write("HK-55 Mode Enabled");
-				EnableHK55 = true;
-			}
-		}
-	}
+            Hotkeys.RegisterHotkey("Set Tank (F12)", Targeting.SetTank, Keys.F12);
+            Logger.Write("[Hot Key][F12] Set Tank");
+        }
+
+        private static void ChangeAoe()
+        {
+            if (EnableAoe)
+            {
+                Logger.Write("AOE Disabled");
+                EnableAoe = false;
+            }
+            else
+            {
+                Logger.Write("AOE Enabled");
+                EnableAoe = true;
+            }
+        }
+
+        private static void ChangePause()
+        {
+            if (PauseRotation)
+            {
+                Logger.Write("Rotation Resumed");
+                PauseRotation = false;
+            }
+            else
+            {
+                Logger.Write("Rotation Paused");
+                PauseRotation = true;
+            }
+        }
+
+        private static void ChangeCharge()
+        {
+            if (EnableCharge)
+            {
+                Logger.Write("Charge Disabled");
+                EnableCharge = false;
+            }
+            else
+            {
+                Logger.Write("Charge Enabled");
+                EnableCharge = true;
+            }
+        }
+
+        private static void ChangeInterrupts()
+        {
+            if (EnableInterrupts)
+            {
+                Logger.Write("Interrupts Disabled");
+                EnableInterrupts = false;
+            }
+            else
+            {
+                Logger.Write("Interrupts Enabled");
+                EnableInterrupts = true;
+            }
+        }
+
+        private static void ChangeSolo()
+        {
+            if (EnableSolo)
+            {
+                Logger.Write("Solo Mode Disabled");
+                EnableSolo = false;
+            }
+            else
+            {
+                Logger.Write("Solo Mode Enabled");
+                EnableSolo = true;
+            }
+        }
+
+        private static void ChangeHK55()
+        {
+            if (EnableHK55)
+            {
+                Logger.Write("HK-55 Mode Disabled");
+                EnableHK55 = false;
+            }
+            else
+            {
+                Logger.Write("HK-55 Mode Enabled");
+                EnableHK55 = true;
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/Extensions.cs
+++ b/trunk/DefaultCombat/Helpers/Extensions.cs
@@ -9,25 +9,25 @@ using Buddy.Swtor.Objects;
 
 namespace DefaultCombat.Helpers
 {
-	public static class Extensions
-	{
-		public delegate bool TorCharacterPredicateDelegate(TorCharacter torCharacter);
+    public static class Extensions
+    {
+        public delegate bool TorCharacterPredicateDelegate(TorCharacter torCharacter);
 
-		public delegate bool TorEffectPredicateDelegate(TorEffect torEffect);
+        public delegate bool TorEffectPredicateDelegate(TorEffect torEffect);
 
-		public delegate bool TorPlayerPredicateDelegate(TorPlayer torPlayer);
+        public delegate bool TorPlayerPredicateDelegate(TorPlayer torPlayer);
 
-		public static Debuff[] DebuffList =
-		{
-			new Debuff("Crushing Affliction (Force)", 0),
-			new Debuff("Crushing Affliction (All)", 0),
-			new Debuff("Corrosive Slime", 0),
-			new Debuff("Laser", 4)
-		};
+        public static Debuff[] DebuffList =
+        {
+            new Debuff("Crushing Affliction (Force)", 0),
+            new Debuff("Crushing Affliction (All)", 0),
+            new Debuff("Corrosive Slime", 0),
+            new Debuff("Laser", 4)
+        };
 
-		public static string[] DebuffNamesCrowdControl =
-		{
-			"Afraid (Mental)", // from Intimidating Roar / Awe
+        public static string[] DebuffNamesCrowdControl =
+        {
+            "Afraid (Mental)", // from Intimidating Roar / Awe
 			"Blinded (Tech)", // from Flash Grenade / Flash Bang
 			"Lifted (Force)", // from Whirlwind / Force Lift
 			"Sliced", // from Slice Droid
@@ -36,357 +36,357 @@ namespace DefaultCombat.Helpers
 			"Stunned" // from Debilitate / Dirty Kick
 		};
 
-		// This table contains the list of debuff names which prevent us from being shielded...
-		public static string[] DebuffNamesShielded =
-		{
-			"Deionized", // Result of Sorcerer shielding
+        // This table contains the list of debuff names which prevent us from being shielded...
+        public static string[] DebuffNamesShielded =
+        {
+            "Deionized", // Result of Sorcerer shielding
 			"Force-imbalance" // Result of Sage shielding
 		};
 
-		private static readonly string[] BuffNamesForCoverVariants = {"Crouch", "Cover"};
+        private static readonly string[] s_buffNamesForCoverVariants = { "Crouch", "Cover" };
 
-		private static readonly IEnumerable<ClassTunables> TunablesByClass = new List<ClassTunables>
-		{
+        private static readonly IEnumerable<ClassTunables> s_tunablesByClass = new List<ClassTunables>
+        {
 			// Republic
 			new ClassTunables
-			{
-				Class = CharacterClass.Knight,
-				RejuvenateAbilityName = "Introspection",
-				SelfBuffName = "Force Might",
-				IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
-				IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.Consular,
-				RejuvenateAbilityName = "Meditation",
-				SelfBuffName = "Force Valor",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
-				IsRejuvenationComplete =
-					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.Smuggler,
-				RejuvenateAbilityName = "Recuperate",
-				SelfBuffName = "Lucky Shots",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
-				IsRejuvenationComplete =
-					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.Trooper,
-				RejuvenateAbilityName = "Recharge and Reload",
-				SelfBuffName = "Fortification",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
-				IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat > 95),
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
+            {
+                Class = CharacterClass.Knight,
+                RejuvenateAbilityName = "Introspection",
+                SelfBuffName = "Force Might",
+                IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
+                IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.Consular,
+                RejuvenateAbilityName = "Meditation",
+                SelfBuffName = "Force Valor",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+                IsRejuvenationComplete =
+                    torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.Smuggler,
+                RejuvenateAbilityName = "Recuperate",
+                SelfBuffName = "Lucky Shots",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+                IsRejuvenationComplete =
+                    torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.Trooper,
+                RejuvenateAbilityName = "Recharge and Reload",
+                SelfBuffName = "Fortification",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+                IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat > 95),
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
 
 			// Empire
 			new ClassTunables
-			{
-				Class = CharacterClass.Warrior,
-				RejuvenateAbilityName = "Channel Hatred",
-				SelfBuffName = "Unnatural Might",
-				IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
-				IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.Inquisitor,
-				RejuvenateAbilityName = "Seethe",
-				SelfBuffName = "Mark of Power",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
-				IsRejuvenationComplete =
-					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.Agent,
-				RejuvenateAbilityName = "Recuperate",
-				SelfBuffName = "Coordination",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
-				IsRejuvenationComplete =
-					torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
-				NormalizedResource = torPlayer => torPlayer.ResourceStat
-			},
-			new ClassTunables
-			{
-				Class = CharacterClass.BountyHunter,
-				RejuvenateAbilityName = "Recharge and Reload",
-				SelfBuffName = "Hunter's Boon",
-				IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat > 30),
-				IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat <= 5),
-				NormalizedResource = torPlayer => 100.0f - Math.Min(torPlayer.ResourceStat, 100.0f)
-			},
+            {
+                Class = CharacterClass.Warrior,
+                RejuvenateAbilityName = "Channel Hatred",
+                SelfBuffName = "Unnatural Might",
+                IsRejuvenationNeeded = torPlayer => torPlayer.HealthPercent < 70,
+                IsRejuvenationComplete = torPlayer => torPlayer.HealthPercent >= 95,
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.Inquisitor,
+                RejuvenateAbilityName = "Seethe",
+                SelfBuffName = "Mark of Power",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+                IsRejuvenationComplete =
+                    torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.Agent,
+                RejuvenateAbilityName = "Recuperate",
+                SelfBuffName = "Coordination",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat < 70),
+                IsRejuvenationComplete =
+                    torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat >= 95),
+                NormalizedResource = torPlayer => torPlayer.ResourceStat
+            },
+            new ClassTunables
+            {
+                Class = CharacterClass.BountyHunter,
+                RejuvenateAbilityName = "Recharge and Reload",
+                SelfBuffName = "Hunter's Boon",
+                IsRejuvenationNeeded = torPlayer => (torPlayer.HealthPercent < 70) || (torPlayer.ResourceStat > 30),
+                IsRejuvenationComplete = torPlayer => (torPlayer.HealthPercent >= 95) && (torPlayer.ResourceStat <= 5),
+                NormalizedResource = torPlayer => 100.0f - Math.Min(torPlayer.ResourceStat, 100.0f)
+            },
 
 			// Boundary condition --
 			new ClassTunables
-			{
-				Class = CharacterClass.Unknown,
-				RejuvenateAbilityName = "UNDEFINED",
-				SelfBuffName = "UNDEFINED",
-				IsRejuvenationNeeded = torPlayer => false,
-				IsRejuvenationComplete = torPlayer => true,
-				NormalizedResource = torPlayer => 0.0f
-			}
-		};
+            {
+                Class = CharacterClass.Unknown,
+                RejuvenateAbilityName = "UNDEFINED",
+                SelfBuffName = "UNDEFINED",
+                IsRejuvenationNeeded = torPlayer => false,
+                IsRejuvenationComplete = torPlayer => true,
+                NormalizedResource = torPlayer => 0.0f
+            }
+        };
 
-		// Derived data structure for quick lookup --
-		private static readonly Dictionary<CharacterClass, ClassTunables> TunablesMap =
-			TunablesByClass.ToDictionary(x => x.Class, x => x);
+        // Derived data structure for quick lookup --
+        private static readonly Dictionary<CharacterClass, ClassTunables> s_tunablesMap =
+            s_tunablesByClass.ToDictionary(x => x.Class, x => x);
 
-		public static bool HasMyBuff(this TorCharacter u, string aura)
-		{
-			return u.Buffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
-		}
+        public static bool HasMyBuff(this TorCharacter u, string aura)
+        {
+            return u.Buffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
+        }
 
-		public static bool HasMyDebuff(this TorCharacter u, string aura)
-		{
-			return u.Debuffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
-		}
+        public static bool HasMyDebuff(this TorCharacter u, string aura)
+        {
+            return u.Debuffs.Any(a => a.Name == aura && a.CasterGuid == BuddyTor.Me.Guid);
+        }
 
-		public static int BuffCount(this TorCharacter p, string buffName)
-		{
-			return !p.HasMyBuff(buffName)
-				? 0
-				: p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
-		}
+        public static int BuffCount(this TorCharacter p, string buffName)
+        {
+            return !p.HasMyBuff(buffName)
+                ? 0
+                : p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
+        }
 
-		public static int DebuffCount(this TorCharacter p, string buffName)
-		{
-			return !p.HasMyDebuff(buffName)
-				? 0
-				: p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
-		}
+        public static int DebuffCount(this TorCharacter p, string buffName)
+        {
+            return !p.HasMyDebuff(buffName)
+                ? 0
+                : p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).GetStacks();
+        }
 
-		public static double BuffTimeLeft(this TorCharacter p, string buffName)
-		{
-			return !p.HasMyBuff(buffName)
-				? 0
-				: p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
-		}
+        public static double BuffTimeLeft(this TorCharacter p, string buffName)
+        {
+            return !p.HasMyBuff(buffName)
+                ? 0
+                : p.Buffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
+        }
 
-		public static double DebuffTimeLeft(this TorCharacter p, string buffName)
-		{
-			return !p.HasMyDebuff(buffName)
-				? 0
-				: p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
-		}
+        public static double DebuffTimeLeft(this TorCharacter p, string buffName)
+        {
+            return !p.HasMyDebuff(buffName)
+                ? 0
+                : p.Debuffs.FirstOrDefault(b => b.Name.Contains(buffName) && b.CasterGuid == BuddyTor.Me.Guid).TimeLeft.TotalSeconds;
+        }
 
-		public static bool HasDebuffCount(this TorCharacter p, string debuff, int stacks)
-		{
-			return p.HasDebuff(debuff) && p.Debuffs.Any(d => d.Name.Contains(debuff) && d.GetStacks() >= stacks);
-		}
+        public static bool HasDebuffCount(this TorCharacter p, string debuff, int stacks)
+        {
+            return p.HasDebuff(debuff) && p.Debuffs.Any(d => d.Name.Contains(debuff) && d.GetStacks() >= stacks);
+        }
 
-		public static bool NeedsCleanse(this TorCharacter p)
-		{
-			foreach (var d in DebuffList)
-			{
-				if (d.Stacks == 0 && p.HasDebuff(d.Name))
-					return true;
+        public static bool NeedsCleanse(this TorCharacter p)
+        {
+            foreach (var d in DebuffList)
+            {
+                if (d.Stacks == 0 && p.HasDebuff(d.Name))
+                    return true;
 
-				if (d.Stacks > 0 && p.HasDebuffCount(d.Name, d.Stacks))
-					return true;
-			}
-			return false;
-		}
+                if (d.Stacks > 0 && p.HasDebuffCount(d.Name, d.Stacks))
+                    return true;
+            }
+            return false;
+        }
 
 
-		public static IEnumerable<TorCharacter> PartyMembers(this TorPlayer torPlayer, bool includeCompanions = true,
-			TorCharacterPredicateDelegate memberQualifier = null)
-		{
-			memberQualifier = memberQualifier ?? (c => true); // resolve playerQualifier to something sane
+        public static IEnumerable<TorCharacter> PartyMembers(this TorPlayer torPlayer, bool includeCompanions = true,
+            TorCharacterPredicateDelegate memberQualifier = null)
+        {
+            memberQualifier = memberQualifier ?? (c => true); // resolve playerQualifier to something sane
 
-			IEnumerable<TorCharacter> partyMembers = torPlayer.PartyPlayers();
+            IEnumerable<TorCharacter> partyMembers = torPlayer.PartyPlayers();
 
-			if (includeCompanions)
-			{
-				partyMembers = partyMembers.Concat(torPlayer.PartyCompanions());
-			}
+            if (includeCompanions)
+            {
+                partyMembers = partyMembers.Concat(torPlayer.PartyCompanions());
+            }
 
-			return partyMembers.Where(c => memberQualifier(c));
-		}
+            return partyMembers.Where(c => memberQualifier(c));
+        }
 
-		public static bool IsPartyRoleTank(this TorCharacter torCharacter)
-		{
-			var role = torCharacter.PartyRole();
-			return (role == Global.PartyRole.MeleeTank) || (role == Global.PartyRole.RangedTank);
-		}
+        public static bool IsPartyRoleTank(this TorCharacter torCharacter)
+        {
+            var role = torCharacter.PartyRole();
+            return (role == Global.PartyRole.MeleeTank) || (role == Global.PartyRole.RangedTank);
+        }
 
-		public static IEnumerable<TorNpc> PartyCompanions(this TorPlayer torPlayer,
-			TorCharacterPredicateDelegate companionQualifier = null)
-		{
-			// Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
+        public static IEnumerable<TorNpc> PartyCompanions(this TorPlayer torPlayer,
+            TorCharacterPredicateDelegate companionQualifier = null)
+        {
+            // Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
 
-			companionQualifier = companionQualifier ?? (ctx => true); // resolve playerQualifier to something sane
+            companionQualifier = companionQualifier ?? (ctx => true); // resolve playerQualifier to something sane
 
-			return torPlayer.PartyPlayers(p => p.IsCompanionInUse() && companionQualifier(p.Companion)).Select(p => p.Companion);
-		}
+            return torPlayer.PartyPlayers(p => p.IsCompanionInUse() && companionQualifier(p.Companion)).Select(p => p.Companion);
+        }
 
-		public static Global.PartyRole PartyRole(this TorCharacter torCharacter)
-		{
-			//Idk if this was working anyway.
-			return Global.PartyRole.RangedDPS;
-		}
+        public static Global.PartyRole PartyRole(this TorCharacter torCharacter)
+        {
+            //Idk if this was working anyway.
+            return Global.PartyRole.RangedDPS;
+        }
 
-		public static bool IsCompanionInUse(this TorPlayer torPlayer)
-		{
-			// Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
-			return (torPlayer.CompanionUnlocked > 0) && (torPlayer.Companion != null);
-		}
+        public static bool IsCompanionInUse(this TorPlayer torPlayer)
+        {
+            // Extension methods guarantee the 'this' argument is never null, so no need to check a contract here
+            return (torPlayer.CompanionUnlocked > 0) && (torPlayer.Companion != null);
+        }
 
-		public static IEnumerable<TorPlayer> PartyPlayers(this TorPlayer torPlayer,
-			TorPlayerPredicateDelegate playerQualifier = null)
-		{
-			playerQualifier = playerQualifier ?? (ctx => true); // resolve playerQualifier to something sane
+        public static IEnumerable<TorPlayer> PartyPlayers(this TorPlayer torPlayer,
+            TorPlayerPredicateDelegate playerQualifier = null)
+        {
+            playerQualifier = playerQualifier ?? (ctx => true); // resolve playerQualifier to something sane
 
-			var playerGroupId = torPlayer.GroupId;
+            var playerGroupId = torPlayer.GroupId;
 
-			// If we're solo, only have the torPlayer on the list...
-			// We can't build this list using the 'normal' query, as all solo players have the common GroupId of zero.
-			// We don't want a list of 'solo' players (what the normal query would do), we want a list with only the solo torPlayer on it.
-			if (playerGroupId == 0)
-			{
-				return ObjectManager.GetObjects<TorPlayer>().Where(p => (p == BuddyTor.Me) && playerQualifier(p));
-			}
+            // If we're solo, only have the torPlayer on the list...
+            // We can't build this list using the 'normal' query, as all solo players have the common GroupId of zero.
+            // We don't want a list of 'solo' players (what the normal query would do), we want a list with only the solo torPlayer on it.
+            if (playerGroupId == 0)
+            {
+                return ObjectManager.GetObjects<TorPlayer>().Where(p => (p == BuddyTor.Me) && playerQualifier(p));
+            }
 
-			// NB: IsInParty() is implemented in terms of PartyPlayers().  Be careful not to implement this method in terms of
-			// IsInParty(); otherwise, infinite recursive descent will occur.
-			return
-				ObjectManager.GetObjects<TorPlayer>().Where(p => !p.IsDeleted && playerQualifier(p) && (p.GroupId == playerGroupId));
-		}
+            // NB: IsInParty() is implemented in terms of PartyPlayers().  Be careful not to implement this method in terms of
+            // IsInParty(); otherwise, infinite recursive descent will occur.
+            return
+                ObjectManager.GetObjects<TorPlayer>().Where(p => !p.IsDeleted && playerQualifier(p) && (p.GroupId == playerGroupId));
+        }
 
-		public static bool IsCrowdControlled(this TorCharacter torCharacter)
-		{
-			return torCharacter.Debuffs.FirstOrDefault(d => DebuffNamesCrowdControl.Contains(d.Name)) != null;
-		}
+        public static bool IsCrowdControlled(this TorCharacter torCharacter)
+        {
+            return torCharacter.Debuffs.FirstOrDefault(d => DebuffNamesCrowdControl.Contains(d.Name)) != null;
+        }
 
-		public static int GetStacks(this TorEffect t)
-		{
-			var result = 0;
-			try
-			{
-				result = t.Stacks;
-			}
-			catch
-			{
-				result = 1;
-			}
-			return result;
-		}
+        public static int GetStacks(this TorEffect t)
+        {
+            var result = 0;
+            try
+            {
+                result = t.Stacks;
+            }
+            catch
+            {
+                result = 1;
+            }
+            return result;
+        }
 
-		public static bool IsValidTarget(this TorCharacter c)
-		{
-			try
-			{
-				return c != null && !c.IsDeleted && c.InCombat && c.IsHostile && !c.IsDead && !c.IsStunned && !c.IsCrowdControlled();
-			}
-			catch
-			{
-				return false;
-			}
-		}
+        public static bool IsValidTarget(this TorCharacter c)
+        {
+            try
+            {
+                return c != null && !c.IsDeleted && c.InCombat && c.IsHostile && !c.IsDead && !c.IsStunned && !c.IsCrowdControlled();
+            }
+            catch
+            {
+                return false;
+            }
+        }
 
-		public static bool BossOrGreater(this TorCharacter unit)
-		{
-			if (unit != null) if (unit.Toughness >= CombatToughness.Boss1) return true;
-			return false;
-		}
+        public static bool BossOrGreater(this TorCharacter unit)
+        {
+            if (unit != null) if (unit.Toughness >= CombatToughness.Boss1) return true;
+            return false;
+        }
 
-		public static bool StrongOrGreater(this TorCharacter unit)
-		{
-			if (unit != null) if (unit.Toughness >= CombatToughness.Strong) return true;
-			return false;
-		}
+        public static bool StrongOrGreater(this TorCharacter unit)
+        {
+            if (unit != null) if (unit.Toughness >= CombatToughness.Strong) return true;
+            return false;
+        }
 
-		public static bool IsHealer(this TorPlayer p)
-		{
-			var result = false;
-			switch (p.Discipline)
-			{
-				case CharacterDiscipline.CombatMedic:
-					result = true;
-					break;
-				case CharacterDiscipline.Bodyguard:
-					result = true;
-					break;
-				case CharacterDiscipline.Medicine:
-					result = true;
-					break;
-				case CharacterDiscipline.Seer:
-					result = true;
-					break;
-				case CharacterDiscipline.Sawbones:
-					result = true;
-					break;
-				case CharacterDiscipline.Corruption:
-					result = true;
-					break;
-			}
-			return result;
-		}
+        public static bool IsHealer(this TorPlayer p)
+        {
+            var result = false;
+            switch (p.Discipline)
+            {
+                case CharacterDiscipline.CombatMedic:
+                    result = true;
+                    break;
+                case CharacterDiscipline.Bodyguard:
+                    result = true;
+                    break;
+                case CharacterDiscipline.Medicine:
+                    result = true;
+                    break;
+                case CharacterDiscipline.Seer:
+                    result = true;
+                    break;
+                case CharacterDiscipline.Sawbones:
+                    result = true;
+                    break;
+                case CharacterDiscipline.Corruption:
+                    result = true;
+                    break;
+            }
+            return result;
+        }
 
-		public static bool IsInCover(this TorCharacter torCharacter)
-		{
-			return torCharacter.Buffs.Any(b => BuffNamesForCoverVariants.Contains(b.Name));
-		}
+        public static bool IsInCover(this TorCharacter torCharacter)
+        {
+            return torCharacter.Buffs.Any(b => s_buffNamesForCoverVariants.Contains(b.Name));
+        }
 
-		public static bool IsBehind(this TorCharacter torCharacter, TorCharacter target)
-		{
-			return Math.Abs(BuddyTor.Me.Heading - target.Heading) <= 150; // && CurrentTarget.IsInRange(0.35f)
-		}
+        public static bool IsBehind(this TorCharacter torCharacter, TorCharacter target)
+        {
+            return Math.Abs(BuddyTor.Me.Heading - target.Heading) <= 150; // && CurrentTarget.IsInRange(0.35f)
+        }
 
-		public static float ResourcePercent(this TorPlayer torPlayer)
-		{
-			return TunablesMap[torPlayer.Class].NormalizedResource(torPlayer);
-		}
+        public static float ResourcePercent(this TorPlayer torPlayer)
+        {
+            return s_tunablesMap[torPlayer.Class].NormalizedResource(torPlayer);
+        }
 
-		public static string RejuvenateAbilityName(this TorPlayer torPlayer)
-		{
-			return TunablesMap[torPlayer.Class].RejuvenateAbilityName;
-		}
+        public static string RejuvenateAbilityName(this TorPlayer torPlayer)
+        {
+            return s_tunablesMap[torPlayer.Class].RejuvenateAbilityName;
+        }
 
-		public static string SelfBuffName(this TorPlayer torPlayer)
-		{
-			return TunablesMap[torPlayer.Class].SelfBuffName;
-		}
+        public static string SelfBuffName(this TorPlayer torPlayer)
+        {
+            return s_tunablesMap[torPlayer.Class].SelfBuffName;
+        }
 
-		private delegate bool PredicateDelegate(TorPlayer torPlayer);
+        private delegate bool PredicateDelegate(TorPlayer torPlayer);
 
-		private delegate float NormalizedResourceDelegate(TorPlayer torPlayer);
+        private delegate float NormalizedResourceDelegate(TorPlayer torPlayer);
 
-		private class ClassTunables
-		{
-			/// <summary>
-			///     The <c>CharacterClass</c> to which this set of <c>ClassTunables</c> applies.
-			/// </summary>
-			public CharacterClass Class = CharacterClass.Unknown;
+        private class ClassTunables
+        {
+            /// <summary>
+            ///     The <c>CharacterClass</c> to which this set of <c>ClassTunables</c> applies.
+            /// </summary>
+            public CharacterClass Class = CharacterClass.Unknown;
 
-			public PredicateDelegate IsRejuvenationComplete = torPlayer => true;
-			public PredicateDelegate IsRejuvenationNeeded = torPlayer => false;
-			public NormalizedResourceDelegate NormalizedResource = torPlayer => 0.0f;
-			public string RejuvenateAbilityName = "UNDEFINED";
-			public string SelfBuffName = "UNDEFINED";
-		}
-	}
+            public PredicateDelegate IsRejuvenationComplete = torPlayer => true;
+            public PredicateDelegate IsRejuvenationNeeded = torPlayer => false;
+            public NormalizedResourceDelegate NormalizedResource = torPlayer => 0.0f;
+            public string RejuvenateAbilityName = "UNDEFINED";
+            public string SelfBuffName = "UNDEFINED";
+        }
+    }
 
-	public class Debuff
-	{
-		public string Name;
-		public int Stacks;
+    public class Debuff
+    {
+        public string Name;
+        public int Stacks;
 
-		public Debuff(string name, int stacks)
-		{
-			Name = name;
-			Stacks = stacks;
-		}
-	}
+        public Debuff(string name, int stacks)
+        {
+            Name = name;
+            Stacks = stacks;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/Global.cs
+++ b/trunk/DefaultCombat/Helpers/Global.cs
@@ -3,39 +3,39 @@
 
 namespace DefaultCombat.Helpers
 {
-	public class Global
-	{
-		public enum PartyRole
-		{
-			MeleeTank,
-			RangedTank,
-			MeleeDPS,
-			RangedDPS,
-			Healer
-		}
+    public class Global
+    {
+        public enum PartyRole
+        {
+            MeleeTank,
+            RangedTank,
+            MeleeDPS,
+            RangedDPS,
+            Healer
+        }
 
-		public const int EnergyMinimum = 65;
-		public const int CellMinimum = 8;
-	}
+        public const int EnergyMinimum = 65;
+        public const int CellMinimum = 8;
+    }
 
-	public class Distance
-	{
-		public const float Melee = 0.4f;
-		public const float MeleeAoE = 0.8f;
-		public const float Ranged = 2.8f;
-		public const float HealAoe = 1.2f;
-		public const float RangedExt = 3.4f;
-	}
+    public class Distance
+    {
+        public const float Melee = 0.4f;
+        public const float MeleeAoE = 0.8f;
+        public const float Ranged = 2.8f;
+        public const float HealAoe = 1.2f;
+        public const float RangedExt = 3.4f;
+    }
 
 
-	public class Health
-	{
-		public const int Max = 95;
-		public const int Shield = 90;
-		public const int High = 85;
-		public const int Mid = 50;
-		public const int Low = 35;
-		public const int Critical = 15;
-		public const int OffHealThreshold = 40;
-	}
+    public class Health
+    {
+        public const int Max = 95;
+        public const int Shield = 90;
+        public const int High = 85;
+        public const int Mid = 50;
+        public const int Low = 35;
+        public const int Critical = 15;
+        public const int OffHealThreshold = 40;
+    }
 }

--- a/trunk/DefaultCombat/Helpers/InventoryManager.cs
+++ b/trunk/DefaultCombat/Helpers/InventoryManager.cs
@@ -9,49 +9,49 @@ using log4net;
 
 namespace DefaultCombat.Helpers
 {
-	public class InventoryManagerItem
-	{
-		public delegate T Selection<out T>(object context);
+    public class InventoryManagerItem
+    {
+        public delegate T Selection<out T>(object context);
 
-		private readonly ILog _log = Log.Get();
+        private readonly ILog _log = Log.Get();
 
-		private readonly Stopwatch _timer;
-		public int CoolDown;
-		public string ItemName;
+        private readonly Stopwatch _timer;
+        public int CoolDown;
+        public string ItemName;
 
-		public InventoryManagerItem(string name, int cd)
-		{
-			ItemName = name;
-			CoolDown = cd;
-			_timer = new Stopwatch();
-			_log.Info(name + "  Created!");
-		}
+        public InventoryManagerItem(string name, int cd)
+        {
+            ItemName = name;
+            CoolDown = cd;
+            _timer = new Stopwatch();
+            _log.Info(name + "  Created!");
+        }
 
-		public Composite UseItem(Selection<bool> reqs = null)
-		{
-			return new Decorator(ret => reqs == null || reqs(ret),
-				new Action(delegate
-				{
-					if (_timer.IsRunning && _timer.Elapsed.TotalSeconds < CoolDown)
-						return RunStatus.Failure;
+        public Composite UseItem(Selection<bool> reqs = null)
+        {
+            return new Decorator(ret => reqs == null || reqs(ret),
+                new Action(delegate
+                {
+                    if (_timer.IsRunning && _timer.Elapsed.TotalSeconds < CoolDown)
+                        return RunStatus.Failure;
 
-					if (!_timer.IsRunning)
-						_timer.Start();
+                    if (!_timer.IsRunning)
+                        _timer.Start();
 
-					foreach (var o in BuddyTor.Me.InventoryEquipment)
-					{
-						if (o.Name.Contains(ItemName))
-						{
-							o.Use();
-							o.Interact();
-							_timer.Stop();
-							_timer.Reset();
-							_timer.Start();
-							return RunStatus.Success;
-						}
-					}
-					return RunStatus.Failure;
-				}));
-		}
-	}
+                    foreach (var o in BuddyTor.Me.InventoryEquipment)
+                    {
+                        if (o.Name.Contains(ItemName))
+                        {
+                            o.Use();
+                            o.Interact();
+                            _timer.Stop();
+                            _timer.Reset();
+                            _timer.Start();
+                            return RunStatus.Success;
+                        }
+                    }
+                    return RunStatus.Failure;
+                }));
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/Logger.cs
+++ b/trunk/DefaultCombat/Helpers/Logger.cs
@@ -6,21 +6,21 @@ using Buddy.Common;
 
 namespace DefaultCombat
 {
-	public static class Logger
-	{
-		public static void Write(string message)
-		{
-			Write(Colors.Green, message);
-		}
+    public static class Logger
+    {
+        public static void Write(string message)
+        {
+            Write(Colors.Green, message);
+        }
 
-		public static void Write(string message, params object[] args)
-		{
-			Write(Colors.Green, message, args);
-		}
+        public static void Write(string message, params object[] args)
+        {
+            Write(Colors.Green, message, args);
+        }
 
-		public static void Write(Color clr, string message, params object[] args)
-		{
-			Logging.Write(clr, "[DefaultCombat] " + message, args);
-		}
-	}
+        public static void Write(Color clr, string message, params object[] args)
+        {
+            Logging.Write(clr, "[DefaultCombat] " + message, args);
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/Rest.cs
+++ b/trunk/DefaultCombat/Helpers/Rest.cs
@@ -14,146 +14,146 @@ using Action = Buddy.BehaviorTree.Action;
 
 namespace DefaultCombat.Helpers
 {
-	public static class Rest
-	{
-		private static int _swtorpid; // For Mounting and Spell Cancel/Stop
-		private static IntPtr _swtorhWnd;
+    public static class Rest
+    {
+        private static int s_swtorpid; // For Mounting and Spell Cancel/Stop
+        private static IntPtr s_swtorhWnd;
 
-		private static TorPlayer Me
-		{
-			get { return BuddyTor.Me; }
-		}
+        private static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
 
-		private static Composite ReviveCompanion
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Me.Companion != null && Me.Companion.IsDead,
-						new PrioritySelector(
-							Spell.WaitForCast(),
-							CommonBehaviors.MoveAndStop(location => Me.Companion.Position, 0.2f, true),
-							Spell.Cast("Revive Companion", on => Me.Companion, when => Me.Companion.Distance <= 0.3f)
-							))
-					);
-			}
-		}
+        private static Composite ReviveCompanion
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Me.Companion != null && Me.Companion.IsDead,
+                        new PrioritySelector(
+                            Spell.WaitForCast(),
+                            CommonBehaviors.MoveAndStop(location => Me.Companion.Position, 0.2f, true),
+                            Spell.Cast("Revive Companion", on => Me.Companion, when => Me.Companion.Distance <= 0.3f)
+                            ))
+                    );
+            }
+        }
 
-		private static Composite Rejuvenate
-		{
-			get
-			{
-				using (BuddyTor.Memory.AcquireFrame())
-				{
-					return new Action(delegate
-					{
-						if (NeedRest())
-						{
-							SetProcessAttrs();
-							if (BuddyTor.Me.IsMoving) Input.MoveStopAll();
-							while (KeepResting())
-							{
-								if (!Me.IsCasting)
-									AbilityManager.Cast(Me.RejuvenateAbilityName(), Me);
+        private static Composite Rejuvenate
+        {
+            get
+            {
+                using (BuddyTor.Memory.AcquireFrame())
+                {
+                    return new Action(delegate
+                    {
+                        if (NeedRest())
+                        {
+                            SetProcessAttrs();
+                            if (BuddyTor.Me.IsMoving) Input.MoveStopAll();
+                            while (KeepResting())
+                            {
+                                if (!Me.IsCasting)
+                                    AbilityManager.Cast(Me.RejuvenateAbilityName(), Me);
 
-								Thread.Sleep(100);
-							}
-							if (Me.IsCasting)
-							{
-								SendMessage(_swtorhWnd, 0x100, (IntPtr) (char) 0x1b, (IntPtr) 0);
-								Thread.Sleep(100);
-							}
-							return RunStatus.Success;
-						}
+                                Thread.Sleep(100);
+                            }
+                            if (Me.IsCasting)
+                            {
+                                SendMessage(s_swtorhWnd, 0x100, (IntPtr)(char)0x1b, (IntPtr)0);
+                                Thread.Sleep(100);
+                            }
+                            return RunStatus.Success;
+                        }
 
-						return RunStatus.Failure;
-					});
-				}
-			}
-		}
+                        return RunStatus.Failure;
+                    });
+                }
+            }
+        }
 
-		public static Composite HandleRest
-		{
-			get
-			{
-				return new PrioritySelector(
-					ReviveCompanion,
-					Rejuvenate
-					);
-			}
-		}
+        public static Composite HandleRest
+        {
+            get
+            {
+                return new PrioritySelector(
+                    ReviveCompanion,
+                    Rejuvenate
+                    );
+            }
+        }
 
-		[DllImport("user32.dll")]
-		private static extern int SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll")]
+        private static extern int SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
 
-		// Used for mounting/keysend
+        // Used for mounting/keysend
 
-		[DllImport("user32.dll")]
-		private static extern bool SetForegroundWindow(IntPtr hWnd);
+        [DllImport("user32.dll")]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
 
-		public static int NormalizedResource()
-		{
-			if (Me.AdvancedClass == AdvancedClass.None)
-			{
-				switch (Me.Class)
-				{
-					//Add cases needed for reverse basic classes
-					case CharacterClass.BountyHunter:
-						return 100 - (int) Me.ResourcePercent();
-					case CharacterClass.Warrior:
-						return 100;
-					case CharacterClass.Knight:
-						return 100;
-					default:
-						return (int) Me.ResourcePercent();
-				}
-			}
-			switch (Me.AdvancedClass)
-			{
-				//Add cases needed for reverse Advance classes
-				case AdvancedClass.Mercenary:
-					return 100 - (int) Me.ResourcePercent();
-				case AdvancedClass.Powertech:
-					return 100 - (int) Me.ResourcePercent();
-				case AdvancedClass.Juggernaut:
-					return 100;
-				case AdvancedClass.Marauder:
-					return 100;
-				case AdvancedClass.Guardian:
-					return 100;
-				case AdvancedClass.Sentinel:
-					return 100;
-				default:
-					return (int) Me.ResourcePercent();
-			}
-		}
+        public static int NormalizedResource()
+        {
+            if (Me.AdvancedClass == AdvancedClass.None)
+            {
+                switch (Me.Class)
+                {
+                    //Add cases needed for reverse basic classes
+                    case CharacterClass.BountyHunter:
+                        return 100 - (int)Me.ResourcePercent();
+                    case CharacterClass.Warrior:
+                        return 100;
+                    case CharacterClass.Knight:
+                        return 100;
+                    default:
+                        return (int)Me.ResourcePercent();
+                }
+            }
+            switch (Me.AdvancedClass)
+            {
+                //Add cases needed for reverse Advance classes
+                case AdvancedClass.Mercenary:
+                    return 100 - (int)Me.ResourcePercent();
+                case AdvancedClass.Powertech:
+                    return 100 - (int)Me.ResourcePercent();
+                case AdvancedClass.Juggernaut:
+                    return 100;
+                case AdvancedClass.Marauder:
+                    return 100;
+                case AdvancedClass.Guardian:
+                    return 100;
+                case AdvancedClass.Sentinel:
+                    return 100;
+                default:
+                    return (int)Me.ResourcePercent();
+            }
+        }
 
-		public static bool NeedRest()
-		{
-			var resource = NormalizedResource();
-			return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 50 || Me.HealthPercent < 90
-																	   || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 90));
-		}
+        public static bool NeedRest()
+        {
+            var resource = NormalizedResource();
+            return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 50 || Me.HealthPercent < 90
+                                                                       || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 90));
+        }
 
-		public static void SetProcessAttrs()
-		{
-			var torMem = 0;
-			foreach (var proc in Process.GetProcesses())
-				if (proc.ProcessName.Contains("swtor") && proc.MainWindowTitle.Contains("Star Wars"))
+        public static void SetProcessAttrs()
+        {
+            var torMem = 0;
+            foreach (var proc in Process.GetProcesses())
+                if (proc.ProcessName.Contains("swtor") && proc.MainWindowTitle.Contains("Star Wars"))
 
-					if (proc.PrivateMemorySize64 > torMem)
-					{
-						_swtorpid = proc.Id;
-						torMem = (int) proc.NonpagedSystemMemorySize64;
-						_swtorhWnd = proc.MainWindowHandle;
-					}
-		}
+                    if (proc.PrivateMemorySize64 > torMem)
+                    {
+                        s_swtorpid = proc.Id;
+                        torMem = (int)proc.NonpagedSystemMemorySize64;
+                        s_swtorhWnd = proc.MainWindowHandle;
+                    }
+        }
 
-		public static bool KeepResting()
-		{
-			var resource = NormalizedResource();
-			return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 100 || Me.HealthPercent < 100
-																	   || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 100));
-		}
-	}
+        public static bool KeepResting()
+        {
+            var resource = NormalizedResource();
+            return !DefaultCombat.MovementDisabled && !Me.InCombat && (resource < 100 || Me.HealthPercent < 100
+                                                                       || (Me.Companion != null && !Me.Companion.IsDead && Me.Companion.HealthPercent < 100));
+        }
+    }
 }

--- a/trunk/DefaultCombat/Helpers/Scavenge.cs
+++ b/trunk/DefaultCombat/Helpers/Scavenge.cs
@@ -12,73 +12,74 @@ using Action = Buddy.BehaviorTree.Action;
 
 namespace DefaultCombat.Helpers
 {
-	//This shit comes from Joe's
-	internal class Scavenge
-	{
-		private static TorPlayer Me
-		{
-			get { return BuddyTor.Me; }
-		}
+    //This shit comes from Joe's
+    internal class Scavenge
+    {
+        private static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
 
-		private static bool HasScav
-		{
-			get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Scavenging")); }
-		}
+        private static bool HasScav
+        {
+            get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Scavenging")); }
+        }
 
-		private static bool HasBio
-		{
-			get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Bioanalysis")); }
-		}
+        private static bool HasBio
+        {
+            get { return Me.ProfessionInfos.Any(p => p.Name.Contains("Bioanalysis")); }
+        }
 
-		public static TorCharacter ScavUnit
-		{
-			get { return ObjectManager.GetObjects<TorNpc>().Where(p => CanHarvestCorpse(p)).FirstOrDefault(); }
-		}
+        public static TorCharacter ScavUnit
+        {
+            get { return ObjectManager.GetObjects<TorNpc>().Where(p => CanHarvestCorpse(p)).FirstOrDefault(); }
+        }
 
-		public static Composite ScavengeCorpse
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => ScavUnit != null,
-						new PrioritySelector(
-							Spell.WaitForCast(),
-							CommonBehaviors.MoveAndStop(location => ScavUnit.Position, 0.2f, true),
-							new Action(ret => ScavUnit.Interact())
-							))
-					);
-			}
-		}
+        public static Composite ScavengeCorpse
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => ScavUnit != null,
+                        new PrioritySelector(
+                            Spell.WaitForCast(),
+                            CommonBehaviors.MoveAndStop(location => ScavUnit.Position, 0.2f, true),
+                            new Action(ret => ScavUnit.Interact())
+                            ))
+                    );
+            }
+        }
 
 
-		public static bool CanHarvestCorpse(TorNpc unit)
-		{
-			var SkillReq = Math.Max(unit.Level - 3, 0)*8;
-			if (unit != null)
-				if (!unit.IsDeleted)
-					if (unit.IsDead && unit.Distance <= 4.0f
-						&&
-						((HasBio && unit.CreatureType == CreatureType.Creature && PISkill("Bioanalysis") >= SkillReq) ||
-						 (HasScav && unit.CreatureType == CreatureType.Droid && PISkill("Scavenging") >= SkillReq))
-						&& StrongOrGreater(unit) && !unit.IsFriendly)
-						if (!Blacklist.Contains(unit.Guid))
-							return true;
+        public static bool CanHarvestCorpse(TorNpc unit)
+        {
+            var SkillReq = Math.Max(unit.Level - 3, 0) * 8;
+            if (unit != null)
+                if (!unit.IsDeleted)
+                    if (unit.IsDead && unit.Distance <= 4.0f
+                        &&
+                        ((HasBio && unit.CreatureType == CreatureType.Creature && PISkill("Bioanalysis") >= SkillReq) ||
+                         (HasScav && unit.CreatureType == CreatureType.Droid && PISkill("Scavenging") >= SkillReq))
+                        && StrongOrGreater(unit) && !unit.IsFriendly)
+                        if (!Blacklist.Contains(unit.Guid))
+                            return true;
 
-			return false;
-		}
+            return false;
+        }
 
-		public static ulong PISkill(string Skill)
-		{
-			foreach (var pi in BuddyTor.Me.ProfessionInfos) if (pi.Name.Contains(Skill)) return (ulong) pi.CurrentLevel;
-			return 0;
-		}
+        public static ulong PISkill(string Skill)
+        {
+            foreach (var pi in BuddyTor.Me.ProfessionInfos) if (pi.Name.Contains(Skill)) return (ulong)pi.CurrentLevel;
+            return 0;
+        }
 
-		public static bool StrongOrGreater(TorCharacter unit)
-		{
-			if (unit != null)
-				if (unit.Toughness == CombatToughness.Strong || unit.Toughness == CombatToughness.Boss1 ||
-					unit.Toughness == CombatToughness.Boss2 || unit.Toughness == CombatToughness.Player) return true;
-			return false;
-		}
-	}
+        public static bool StrongOrGreater(TorCharacter unit)
+        {
+            if (unit != null)
+                if (unit.Toughness == CombatToughness.Strong || unit.Toughness == CombatToughness.Boss1 ||
+                    unit.Toughness == CombatToughness.Boss2 || unit.Toughness == CombatToughness.Player)
+                    return true;
+            return false;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Properties/AssemblyInfo.cs
+++ b/trunk/DefaultCombat/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Bossland GmbH")]
 [assembly: AssemblyProduct("DefaultCombat.Properties")]
-[assembly: AssemblyCopyright("Copyright © Bossland GmbH 2015")]
+[assembly: AssemblyCopyright("Copyright \u00A9 Bossland GmbH 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/trunk/DefaultCombat/Routines/Advanced/Assassin/Darkness.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Assassin/Darkness.cs
@@ -7,101 +7,101 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Darkness : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Assassin Darkness"; }
-		}
+    internal class Darkness : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Assassin Darkness"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power"),
-					Spell.Cast("Guard", on => Me.Companion,	ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Dark Ward", ret => !Me.HasBuff("Dark Ward")),
-					Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Recklessness"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Dark Ward", ret => !Me.HasBuff("Dark Ward")),
+                    Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
+                    Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Recklessness"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Rotation
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Wither"),
-					Spell.Cast("Shock"),
-					Spell.Cast("Maul", ret => Me.HasBuff("Conspirator's Cloak")),
-					Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Discharge"),
-					Spell.Cast("Thrash"),
-					Spell.Cast("Saber Strike"),
-					Spell.Cast("Depredating Volts", ret => Me.BuffCount("Harnessed Darkness") > 2),
-					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Targeting.ShouldAoe,
-						new PrioritySelector(
-							Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-							Spell.Cast("Wither"),
-							Spell.Cast("Discharge"))),
-					new Decorator(ret => Targeting.ShouldPbaoe,
-						Spell.Cast("Lacerate", ret => Me.ForcePercent >= 60))
-					);
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Wither"),
+                    Spell.Cast("Shock"),
+                    Spell.Cast("Maul", ret => Me.HasBuff("Conspirator's Cloak")),
+                    Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Discharge"),
+                    Spell.Cast("Thrash"),
+                    Spell.Cast("Saber Strike"),
+                    Spell.Cast("Depredating Volts", ret => Me.BuffCount("Harnessed Darkness") > 2),
+                    Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Targeting.ShouldAoe,
+                        new PrioritySelector(
+                            Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                            Spell.Cast("Wither"),
+                            Spell.Cast("Discharge"))),
+                    new Decorator(ret => Targeting.ShouldPbaoe,
+                        Spell.Cast("Lacerate", ret => Me.ForcePercent >= 60))
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Assassin/Deception.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Assassin/Deception.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Deception : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Assassin Deception"; }
-		}
+    internal class Deception : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Assassin Deception"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled && !Me.IsMounted)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled && !Me.IsMounted)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Recklessness", ret => Me.BuffCount("Static Charge") < 1 && Me.InCombat),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
+                    Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Recklessness", ret => Me.BuffCount("Static Charge") < 1 && Me.InCombat),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Buff("Force Speed",	ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Interrupts
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Low Slash", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Interrupts
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Low Slash", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
-					//Rotation
-					Spell.Cast("Discharge", ret => Me.BuffCount("Static Charge") == 3),
-					Spell.Cast("Ball Lightning", ret => Me.BuffCount("Induction") == 2 && Me.Level >= 57),
-					Spell.Cast("Shock", ret => Me.BuffCount("Induction") == 2 && Me.Level < 57),
-					Spell.Cast("Maul", ret => Me.HasBuff("Duplicity") && Me.IsBehind(Me.CurrentTarget)),
-					Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Reaping Strike", ret => Me.BuffCount("Discharge") < 3),
-					Spell.Cast("Voltaic Slash", ret => Me.Level >= 26),
-					Spell.Cast("Thrash", ret => Me.Level < 26),
-					Spell.Cast("Saber Strike", ret => Me.ForcePercent <= 25),
-					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Discharge", ret => Me.BuffCount("Static Charge") == 3),
+                    Spell.Cast("Ball Lightning", ret => Me.BuffCount("Induction") == 2 && Me.Level >= 57),
+                    Spell.Cast("Shock", ret => Me.BuffCount("Induction") == 2 && Me.Level < 57),
+                    Spell.Cast("Maul", ret => Me.HasBuff("Duplicity") && Me.IsBehind(Me.CurrentTarget)),
+                    Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Reaping Strike", ret => Me.BuffCount("Discharge") < 3),
+                    Spell.Cast("Voltaic Slash", ret => Me.Level >= 26),
+                    Spell.Cast("Thrash", ret => Me.Level < 26),
+                    Spell.Cast("Saber Strike", ret => Me.ForcePercent <= 25),
+                    Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Lacerate", ret => Me.ForcePercent >= 60)
-					));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Lacerate", ret => Me.ForcePercent >= 60)
+                    ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Assassin/Hatred.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Assassin/Hatred.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Hatred : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Assasin Hatred"; }
-		}
+    public class Hatred : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Assasin Hatred"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Recklessness"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
+                    Spell.Buff("Overcharge Saber", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Force Shroud", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Recklessness"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Phantom Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Low Force
-					Spell.Cast("Saber Strike", ret => Me.ForcePercent <= 40),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.CastOnGround("Death Field"),
-					Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Bloodletting")),
-					Spell.Cast("Eradicate", ret => Me.HasBuff("Raze") && Me.Level >= 26),
-					Spell.DoT("Discharge", "Shocked (Discharge)"),
-					Spell.DoT("Creeping Terror", "Creeping Terror"),
-					Spell.Cast("Leeching Strike"),
-					Spell.Cast("Thrash", ret => Me.Force > 70),
-					Spell.Buff("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Force
+                    Spell.Cast("Saber Strike", ret => Me.ForcePercent <= 40),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Death Field"),
-						Spell.DoT("Discharge", "Shocked (Discharge)"),
-						Spell.DoT("Creeping Terror", "Creeping Terror"),
-						Spell.Cast("Lacerate", ret =>	Me.CurrentTarget.HasDebuff("Shocked (Discharge)") && Me.CurrentTarget.HasDebuff("Creeping Terror") &&	Me.ForcePercent >= 60 && Targeting.ShouldPbaoe)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.CastOnGround("Death Field"),
+                    Spell.Cast("Assassinate", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Bloodletting")),
+                    Spell.Cast("Eradicate", ret => Me.HasBuff("Raze") && Me.Level >= 26),
+                    Spell.DoT("Discharge", "Shocked (Discharge)"),
+                    Spell.DoT("Creeping Terror", "Creeping Terror"),
+                    Spell.Cast("Leeching Strike"),
+                    Spell.Cast("Thrash", ret => Me.Force > 70),
+                    Spell.Buff("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Death Field"),
+                        Spell.DoT("Discharge", "Shocked (Discharge)"),
+                        Spell.DoT("Creeping Terror", "Creeping Terror"),
+                        Spell.Cast("Lacerate", ret => Me.CurrentTarget.HasDebuff("Shocked (Discharge)") && Me.CurrentTarget.HasDebuff("Creeping Terror") && Me.ForcePercent >= 60 && Targeting.ShouldPbaoe)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Commando/AssaultSpecialist.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Commando/AssaultSpecialist.cs
@@ -7,112 +7,112 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class AssaultSpecialist : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Commando Assault Specialist"; }
-		}
+    internal class AssaultSpecialist : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Commando Assault Specialist"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
-					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
-					Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
+                    Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
+                    Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Me.ResourcePercent() < 60,
-						new PrioritySelector(
-							Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
-							Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
-							Spell.Cast("Hammer Shot")
-							)),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Me.ResourcePercent() < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
+                            Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
+                            Spell.Cast("Hammer Shot")
+                            )),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Med Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Bacta Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Medical Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
-					
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
-					Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
-					Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
-					Spell.Cast("Assault Plastique"),
-					Spell.DoT("Serrated Bolt", "Bleeding"),
-					Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
-					Spell.Cast("Electro Net"),
-					Spell.Cast("Full Auto"),
-					Spell.Cast("Mag Bolt", ret => Me.Level >= 57),
-					Spell.Cast("High Impact Bolt", ret => Me.Level < 57),
-					Spell.Cast("Charged Bolts"),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Mortar Volley"),
-						Spell.DoT("Serrated Bolt", "Bleeding"),
-						Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
-						Spell.Cast("Plasma Grenade", ret => Me.CurrentTarget.HasDebuff("Burning (Incendiary Round)")),
-						Spell.Cast("Sticky Grenade", ret => Me.CurrentTarget.HasDebuff("Bleeding")),
-						Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
-						Spell.CastOnGround("Hail of Bolts", ret => Me.ResourcePercent() >= 90)
-						));
-			}
-		}
-	}
+                    //Solo Mode
+                    Spell.Cast("Med Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Bacta Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Medical Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Mag Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level >= 57),
+                    Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator") && Me.Level < 57),
+                    Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
+                    Spell.Cast("Assault Plastique"),
+                    Spell.DoT("Serrated Bolt", "Bleeding"),
+                    Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
+                    Spell.Cast("Electro Net"),
+                    Spell.Cast("Full Auto"),
+                    Spell.Cast("Mag Bolt", ret => Me.Level >= 57),
+                    Spell.Cast("High Impact Bolt", ret => Me.Level < 57),
+                    Spell.Cast("Charged Bolts"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Mortar Volley"),
+                        Spell.DoT("Serrated Bolt", "Bleeding"),
+                        Spell.DoT("Incendiary Round", "Burning (Incendiary Round)"),
+                        Spell.Cast("Plasma Grenade", ret => Me.CurrentTarget.HasDebuff("Burning (Incendiary Round)")),
+                        Spell.Cast("Sticky Grenade", ret => Me.CurrentTarget.HasDebuff("Bleeding")),
+                        Spell.Cast("Explosive Round", ret => Me.HasBuff("Hyper Assault Rounds")),
+                        Spell.CastOnGround("Hail of Bolts", ret => Me.ResourcePercent() >= 90)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Commando/CombatMedic.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Commando/CombatMedic.cs
@@ -7,107 +7,107 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class CombatMedic : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Commando Combat Medic"; }
-		}
+    internal class CombatMedic : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Commando Combat Medic"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Supercharged Cell",	ret => Me.ResourceStat >= 20 && HealTarget != null && HealTarget.HealthPercent <= 80 &&	Me.BuffCount("Supercharge") == 10),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
-					Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 50),
-					Spell.Cast("Tech Override", ret => Tank != null && Tank.HealthPercent <= 50),
-					Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Supercharged Cell", ret => Me.ResourceStat >= 20 && HealTarget != null && HealTarget.HealthPercent <= 80 && Me.BuffCount("Supercharge") == 10),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 50),
+                    Spell.Cast("Tech Override", ret => Tank != null && Tank.HealthPercent <= 50),
+                    Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement 
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("High Impact Bolt"),
-					Spell.Cast("Full Auto"),
-					Spell.Cast("Charged Bolts", ret => Me.ResourceStat >= 70),
-					Spell.Cast("Hammer Shot"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement 
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-					//AoE Healing 
-					new Decorator(ctx => Tank != null,
-						Spell.CastOnGround("Kolto Bomb", on => Tank.Position, ret => !Tank.HasBuff("Invigorated") && Me.InCombat)),
-					
-					//Legacy Heroic Moment Ability
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					
-					//Dispel 
-					Spell.Cleanse("Field Aid"),
-					
-					//Single Target Healing 
-					Spell.Heal("Bacta Infusion", 80),
-					Spell.Heal("Successive Treatment", 90),
-					Spell.Heal("Advanced Medical Probe", 80),
-					Spell.Heal("Medical Probe", 75),
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("High Impact Bolt"),
+                    Spell.Cast("Full Auto"),
+                    Spell.Cast("Charged Bolts", ret => Me.ResourceStat >= 70),
+                    Spell.Cast("Hammer Shot"),
 
-					//Keep Trauma Probe on Tank 
-					Spell.Heal("Trauma Probe", on => HealTarget, 100, ret => HealTarget != null && HealTarget.BuffCount("Trauma Probe") <= 1),
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-					//To keep Supercharge buff up; filler heal 
-					Spell.Heal("Med Shot", onUnit => Tank, 100, ret => Tank != null && Me.InCombat)
-					);
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+
+                    //AoE Healing 
+                    new Decorator(ctx => Tank != null,
+                        Spell.CastOnGround("Kolto Bomb", on => Tank.Position, ret => !Tank.HasBuff("Invigorated") && Me.InCombat)),
+
+                    //Legacy Heroic Moment Ability
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+
+                    //Dispel 
+                    Spell.Cleanse("Field Aid"),
+
+                    //Single Target Healing 
+                    Spell.Heal("Bacta Infusion", 80),
+                    Spell.Heal("Successive Treatment", 90),
+                    Spell.Heal("Advanced Medical Probe", 80),
+                    Spell.Heal("Medical Probe", 75),
+
+                    //Keep Trauma Probe on Tank 
+                    Spell.Heal("Trauma Probe", on => HealTarget, 100, ret => HealTarget != null && HealTarget.BuffCount("Trauma Probe") <= 1),
+
+                    //To keep Supercharge buff up; filler heal 
+                    Spell.Heal("Med Shot", onUnit => Tank, 100, ret => Tank != null && Me.InCombat)
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Commando/Gunnery.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Commando/Gunnery.cs
@@ -7,100 +7,100 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Gunnery : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Commando Gunnery"; }
-		}
+    internal class Gunnery : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Commando Gunnery"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
-					Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
-					Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
-					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 70),
+                    Spell.Cast("Echoing Deterrence", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourceStat <= 40),
+                    Spell.Buff("Supercharged Cell", ret => Me.BuffCount("Supercharge") == 10),
+                    Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 60),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Hammer Shot", ret => Me.ResourcePercent() < 60),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Hammer Shot", ret => Me.ResourcePercent() < 60),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Med Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Bacta Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Medical Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Demolition Round", ret => Me.CurrentTarget.HasDebuff("Gravity Vortex")),
-					Spell.Cast("Electro Net"),
-					Spell.Cast("High Impact Bolt", ret => Me.BuffCount("Charged Barrel") == 5),
-					Spell.Cast("Boltstorm"),
-					Spell.Cast("Vortex Bolt"),
-					Spell.Cast("Grav Round"),
-					Spell.Cast("Hammer Shots"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Med Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Bacta Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Medical Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Mortar Volley", ret => Me.HasBuff("Reserve Powercell")),
-						Spell.Cast("Plasma Grenade", ret => Me.ResourceStat >= 90 && Me.HasBuff("Tech Override")),
-						Spell.Cast("Sticky Grenade"),
-						Spell.CastOnGround("Hail of Bolts", ret => Me.ResourceStat >= 90)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Demolition Round", ret => Me.CurrentTarget.HasDebuff("Gravity Vortex")),
+                    Spell.Cast("Electro Net"),
+                    Spell.Cast("High Impact Bolt", ret => Me.BuffCount("Charged Barrel") == 5),
+                    Spell.Cast("Boltstorm"),
+                    Spell.Cast("Vortex Bolt"),
+                    Spell.Cast("Grav Round"),
+                    Spell.Cast("Hammer Shots"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Mortar Volley", ret => Me.HasBuff("Reserve Powercell")),
+                        Spell.Cast("Plasma Grenade", ret => Me.ResourceStat >= 90 && Me.HasBuff("Tech Override")),
+                        Spell.Cast("Sticky Grenade"),
+                        Spell.CastOnGround("Hail of Bolts", ret => Me.ResourceStat >= 90)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Guardian/Defense.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Guardian/Defense.cs
@@ -12,108 +12,108 @@ using Targeting = DefaultCombat.Core.Targeting;
 
 namespace DefaultCombat.Routines
 {
-	internal class Defense : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Guardian Defense"; }
-		}
+    internal class Defense : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Guardian Defense"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might"),
-					Spell.Cast("Guard", on => Me.Companion,	ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Enure", ret => Me.HealthPercent <= 80),
-					Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
-					Spell.Buff("Warding Call", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Enure", ret => Me.HealthPercent <= 80),
+                    Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
+                    Spell.Buff("Warding Call", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Dispatch", ret => Me.HasBuff("Ardent Advocate")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Dispatch", ret => Me.HasBuff("Ardent Advocate")),
                     Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
                     Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Interrupts
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Hilt Bash", ret => !Me.CurrentTarget.IsStunned && Me.ActionPoints >= 7 && AbilityManager.CanCast("Guardian Slash", Me.CurrentTarget)),
-					Spell.Cast("Riposte"),
-					Spell.Cast("Warding Strike", ret => Me.ActionPoints <= 6 || !Me.HasBuff("Warding Strike")),
-					Spell.Cast("Guardian Slash"),
-					Spell.Cast("Blade Barrage"),
-					Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Blade Storm"),
-					Spell.Cast("Force Sweep", ret => !Me.CurrentTarget.HasDebuff("Unsteady (Force)") && Me.CurrentTarget.Distance <= 0.5f),
-					Spell.Cast("Freezing Force", ret => AbilityManager.HasAbility("Persistent Chill") && Me.CurrentTarget.Distance <= 0.5f && !Me.CurrentTarget.HasMyDebuff("Freezing Force")),
-					Spell.Cast("Saber Throw", ret => Me.ActionPoints <= 3),
-					Spell.Cast("Slash", ret => !Me.CurrentTarget.HasDebuff("Trauma")),
-					Spell.Cast("Slash", ret => Me.ActionPoints >= 9),
-					Spell.Cast("Strike"),
-					Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
+                    //Interrupts
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Hilt Bash", ret => !Me.CurrentTarget.IsStunned && Me.ActionPoints >= 7 && AbilityManager.CanCast("Guardian Slash", Me.CurrentTarget)),
+                    Spell.Cast("Riposte"),
+                    Spell.Cast("Warding Strike", ret => Me.ActionPoints <= 6 || !Me.HasBuff("Warding Strike")),
+                    Spell.Cast("Guardian Slash"),
+                    Spell.Cast("Blade Barrage"),
+                    Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Blade Storm"),
+                    Spell.Cast("Force Sweep", ret => !Me.CurrentTarget.HasDebuff("Unsteady (Force)") && Me.CurrentTarget.Distance <= 0.5f),
+                    Spell.Cast("Freezing Force", ret => AbilityManager.HasAbility("Persistent Chill") && Me.CurrentTarget.Distance <= 0.5f && !Me.CurrentTarget.HasMyDebuff("Freezing Force")),
+                    Spell.Cast("Saber Throw", ret => Me.ActionPoints <= 3),
+                    Spell.Cast("Slash", ret => !Me.CurrentTarget.HasDebuff("Trauma")),
+                    Spell.Cast("Slash", ret => Me.ActionPoints >= 9),
+                    Spell.Cast("Strike"),
+                    Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Guardian Slash", ret => Me.HasBuff("Warding Strike")),
-						Spell.Cast("Warding Strike", ret => !Me.HasBuff("Warding Strike")),
-						Spell.Cast("Force Sweep"),
-						Spell.DoT("Freezing Force", "Freezing Force", 0, ret => Me.CurrentTarget.Distance <= 0.8f),						
-						Spell.Cast("Cyclone Slash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Guardian Slash", ret => Me.HasBuff("Warding Strike")),
+                        Spell.Cast("Warding Strike", ret => !Me.HasBuff("Warding Strike")),
+                        Spell.Cast("Force Sweep"),
+                        Spell.DoT("Freezing Force", "Freezing Force", 0, ret => Me.CurrentTarget.Distance <= 0.8f),
+                        Spell.Cast("Cyclone Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Guardian/Focus.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Guardian/Focus.cs
@@ -7,100 +7,104 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Focus : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Guardian Focus"; }
-		}
+    internal class Focus : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Guardian Focus"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
-					Spell.Buff("Enure", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6 || Me.BuffCount("Singularity") < 3),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
+                    Spell.Buff("Enure", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6 || Me.BuffCount("Singularity") < 3),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Interrupts
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Awe", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Stasis", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Focused Burst", ret => Me.HasBuff("Felling Blow") && Me.BuffCount("Singularity") == 3),
-					Spell.Cast("Zealous Leap", ret => !Me.HasBuff("Felling Blow")),
-					Spell.Cast("Force Exhaustion", ret => Me.BuffCount("Singularity") < 3),
-					Spell.Cast("Blade Storm", ret => Me.HasBuff("Momentum")),
-					Spell.Cast("Concentrated Slice"),
-					Spell.Cast("Blade Barrage"),
-					Spell.Cast("Riposte"),
-					Spell.Cast("Sundering Strike", ret => Me.ActionPoints < 7),
-					Spell.Cast("Strike"),
-					Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
+                    //Interrupts
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Awe", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Stasis", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Force Exhaustion", ret => !Me.HasBuff("Protective Focus")),
+                    Spell.Cast("Blade Storm", ret => !Me.HasBuff("Protective Focus")),
+                    Spell.Cast("Sundering Strike", ret => !Me.HasBuff("Protective Focus")),
+                    Spell.Cast("Blade Barrage"),
+                    Spell.Cast("Focused Burst", ret => Me.HasBuff("Felling Blow") && Me.BuffCount("Singularity") < 3),
+                    Spell.Cast("Concentrated Slice", ret => Me.HasBuff("Heightened Power")),
+                    Spell.Cast("Zealous Leap"),
+                    Spell.Cast("Riposte"),
+                    Spell.Cast("Dispatch"),
+                    Spell.Cast("Strike", ret => Me.Level <= 22 && Me.ActionPoints <= 5),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Force Sweep", ret => Me.HasBuff("Felling Blow") && Me.BuffCount("Singularity") == 3),
-						Spell.Cast("Cyclone Smash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Saber Throw"),
+                        Spell.Cast("Zealous Leap"),
+                        Spell.Cast("Force Sweep"),
+                        Spell.Cast("Freezing Force"),
+                        Spell.Cast("Cyclone Slash"),
+                        Spell.Cast("Sundering Strike")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Guardian/Vigilance.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Guardian/Vigilance.cs
@@ -7,103 +7,103 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Vigilance : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Guardian Vigilance"; }
-		}
+    internal class Vigilance : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Guardian Vigilance"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
-					Spell.Buff("Enure", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Focused Defense", ret => Me.HealthPercent < 70),
+                    Spell.Buff("Enure", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Combat Focus", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Interrupts
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Overhead Slash"),
-					Spell.Cast("Whirling Blade", ret => Me.HasBuff("Ardent Advocate")),
-					Spell.Cast("Plasma Brand"),
-					Spell.Cast("Blade Storm"),
-					Spell.Cast("Vigilant Thrust", ret => Me.CurrentTarget.Distance <= 0.5f),
-					Spell.Cast("Blade Barrage"),
-					Spell.Cast("Whirling Blade", ret => Me.HasBuff("Keening") || Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Combat Focus", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Freezing Force", ret => Me.Level >= 62 && Me.CurrentTarget.Distance <= 0.5f && !Me.CurrentTarget.HasMyDebuff("Freezing Force")),
-					Spell.Cast("Sundering Strike", ret => Me.ActionPoints <= 7),
-					Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
-					Spell.Cast("Saber Throw", ret => Me.ActionPoints <= 3),
-					Spell.Cast("Riposte", ret => Me.ActionPoints > 9),
-					Spell.Cast("Slash", ret => Me.ActionPoints > 9),
+                    //Interrupts
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Overhead Slash"),
+                    Spell.Cast("Plasma Brand"),
+                    Spell.Cast("Blade Storm", ret => Me.BuffCount("Force Rush") == 2),
+                    Spell.Cast("Vigilant Thrust"),
+                    Spell.Cast("Blade Barrage"),
+                    Spell.Cast("Whirling Blade", ret => Me.HasBuff("Keening") || Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Sundering Strike", ret => Me.ActionPoints <= 7),
+                    Spell.Cast("Freezing Force", ret => Me.ActionPoints >= 11),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Vigilant Thrust",	ret =>	Me.Level >= 58 && Me.CurrentTarget.HasDebuff("Burning (Plasma Brand)") && Me.CurrentTarget.HasDebuff("Burning (Burning Purpose)") && Me.CurrentTarget.HasDebuff("Burning (Burning Blade)")),
-						Spell.Cast("Force Sweep",	ret =>	Me.Level < 57 && Me.CurrentTarget.HasDebuff("Burning (Plasma Brand)") && Me.CurrentTarget.HasDebuff("Burning (Burning Purpose)") && Me.CurrentTarget.HasDebuff("Burning (Burning Blade)")),
-						Spell.Cast("Cyclone Slash",	ret => Me.CurrentTarget.HasDebuff("Burning (Plasma Brand)") || Me.CurrentTarget.HasDebuff("Burning (Burning Purpose)") ||	Me.CurrentTarget.HasDebuff("Burning (Burning Blade)"))
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Cyclone Slash"),
+                        Spell.Cast("Vigilant Thrust"),
+                        Spell.Cast("Plasma Brand"),
+                        Spell.Cast("Overhead Slash"),
+                        Spell.Cast("Freezing Force", ret => Me.ActionPoints <= 2)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Gunslinger/DirtyFighting.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Gunslinger/DirtyFighting.cs
@@ -7,98 +7,98 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class DirtyFighting : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Gunslinger Dirty Fighting"; }
-		}
+    internal class DirtyFighting : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Gunslinger Dirty Fighting"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
-					Spell.Buff("Smuggler's Luck", ret => Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Illegal Mods", ret => Me.CurrentTarget.BossOrGreater()),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
+                    Spell.Buff("Smuggler's Luck", ret => Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Illegal Mods", ret => Me.CurrentTarget.BossOrGreater()),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Low Energy
-					Spell.Cast("Flurry of Bolts", ret => Me.EnergyPercent < 60),
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.DoT("Vital Shot", "Vital Shot"),
-					Spell.DoT("Shrap Bomb", "Shrap Bomb"),
-					Spell.Cast("Hemorrhaging Blast", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb")),
-					Spell.Cast("Wounding Shots", ret => Me.CurrentTarget.DebuffTimeLeft("Vital Shot") > 3 && Me.CurrentTarget.DebuffTimeLeft("Shrap Bomb") > 3),
-					Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Speed Shot"),
-					Spell.Cast("Dirty Blast", ret => Me.Level >= 57),
-					Spell.Cast("Charged Burst", ret => Me.Level < 57),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Energy
+                    Spell.Cast("Flurry of Bolts", ret => Me.EnergyPercent < 60),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.Cast("Thermal Grenade"),
-						Spell.Cast("Shrap Bomb", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && !Me.CurrentTarget.HasDebuff("Shrap Bomb")),
-						Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.DoT("Vital Shot", "Vital Shot"),
+                    Spell.DoT("Shrap Bomb", "Shrap Bomb"),
+                    Spell.Cast("Hemorrhaging Blast", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb")),
+                    Spell.Cast("Wounding Shots", ret => Me.CurrentTarget.DebuffTimeLeft("Vital Shot") > 3 && Me.CurrentTarget.DebuffTimeLeft("Shrap Bomb") > 3),
+                    Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Speed Shot"),
+                    Spell.Cast("Dirty Blast", ret => Me.Level >= 57),
+                    Spell.Cast("Charged Burst", ret => Me.Level < 57),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.Cast("Thermal Grenade"),
+                        Spell.Cast("Shrap Bomb", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && !Me.CurrentTarget.HasDebuff("Shrap Bomb")),
+                        Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Gunslinger/Saboteur.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Gunslinger/Saboteur.cs
@@ -7,108 +7,108 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Saboteur : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Gunslinger Saboteur"; }
-		}
+    internal class Saboteur : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Gunslinger Saboteur"; }
+        }
 
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots")
+                    );
+            }
+        }
 
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
-					Spell.Buff("Smuggler's Luck", ret => Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Illegal Mods", ret => Me.CurrentTarget.BossOrGreater()),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
+                    Spell.Buff("Smuggler's Luck", ret => Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Illegal Mods", ret => Me.CurrentTarget.BossOrGreater()),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60,
-						new PrioritySelector(
-							Spell.Cast("Thermal Grenade", ret => Me.HasBuff("Seize the Moment")),
-							Spell.Cast("Flurry of Bolts")
-							)),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Thermal Grenade", ret => Me.HasBuff("Seize the Moment")),
+                            Spell.Cast("Flurry of Bolts")
+                            )),
 
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-										
-										
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Explosive Charge"),
-					Spell.DoTGround("Incendiary Grenade", 9000),
-					Spell.Cast("Speed Shot"),
-					Spell.DoT("Shock Charge", "Shock Charge"),
-					Spell.Cast("Sabotage", ret => Me.CurrentTarget.HasDebuff("Shock Charge")),
-					Spell.Cast("Thermal Grenade", ret => Me.HasBuff("Seize the Moment")),
-					Spell.CastOnGround("XS Freighter Flyby", ret => Me.EnergyPercent > 75),
-					Spell.DoT("Vital Shot", "Vital Shot"),
-					Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
-
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10),
-						Spell.Cast("Incendiary Grenade"),
-						Spell.Cast("Thermal Grenade")
-						));
-			}
-		}
-	}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Explosive Charge"),
+                    Spell.DoTGround("Incendiary Grenade", 9000),
+                    Spell.Cast("Speed Shot"),
+                    Spell.DoT("Shock Charge", "Shock Charge"),
+                    Spell.Cast("Sabotage", ret => Me.CurrentTarget.HasDebuff("Shock Charge")),
+                    Spell.Cast("Thermal Grenade", ret => Me.HasBuff("Seize the Moment")),
+                    Spell.CastOnGround("XS Freighter Flyby", ret => Me.EnergyPercent > 75),
+                    Spell.DoT("Vital Shot", "Vital Shot"),
+                    Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10),
+                        Spell.Cast("Incendiary Grenade"),
+                        Spell.Cast("Thermal Grenade")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Gunslinger/Sharpshooter.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Gunslinger/Sharpshooter.cs
@@ -7,109 +7,109 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Sharpshooter : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Gunslinger Sharpshooter"; }
-		}
+    internal class Sharpshooter : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Gunslinger Sharpshooter"; }
+        }
 
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots")
+                    );
+            }
+        }
 
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-				  Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Burst Volley", ret => !Buddy.CommonBot.AbilityManager.CanCast("Penetrating Rounds", Me.CurrentTarget)),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
-					Spell.Buff("Smuggler's Luck"),
-					Spell.Buff("Illegal Mods"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                  Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Burst Volley", ret => !Buddy.CommonBot.AbilityManager.CanCast("Penetrating Rounds", Me.CurrentTarget)),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 50),
+                    Spell.Buff("Smuggler's Luck"),
+                    Spell.Buff("Illegal Mods"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60 && !Buddy.CommonBot.AbilityManager.CanCast("Cool Head", Me),
-						new PrioritySelector(
-							Spell.Cast("Flurry of Bolts")
-							)),
-							
-							
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Trickshot"),
-					Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Penetrating Rounds", ret => Me.Level >= 26),
-					Spell.Cast("Speed Shot", ret => Me.Level < 26),
-					new Decorator(ret => Me.BuffCount("Charged Aim") == 2,
-						new PrioritySelector(						
-							Spell.Cast("Aimed Shot")
-							)),
-					Spell.Cast("Vital Shot", ret => !Me.CurrentTarget.HasMyDebuff("Vital Shot") || Me.CurrentTarget.DebuffTimeLeft("Vital Shot") <= 2),
-					Spell.Cast("Charged Burst"),
-
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60 && !Buddy.CommonBot.AbilityManager.CanCast("Cool Head", Me),
+                        new PrioritySelector(
+                            Spell.Cast("Flurry of Bolts")
+                            )),
 
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.Cast("Thermal Grenade"),
-						Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
-						));
-			}
-		}
-	}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Trickshot"),
+                    Spell.Cast("Quickdraw", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Penetrating Rounds", ret => Me.Level >= 26),
+                    Spell.Cast("Speed Shot", ret => Me.Level < 26),
+                    new Decorator(ret => Me.BuffCount("Charged Aim") == 2,
+                        new PrioritySelector(
+                            Spell.Cast("Aimed Shot")
+                            )),
+                    Spell.Cast("Vital Shot", ret => !Me.CurrentTarget.HasMyDebuff("Vital Shot") || Me.CurrentTarget.DebuffTimeLeft("Vital Shot") <= 2),
+                    Spell.Cast("Charged Burst"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("XS Freighter Flyby", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.Cast("Thermal Grenade"),
+                        Spell.CastOnGround("Sweeping Gunfire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Immortal.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Immortal.cs
@@ -7,104 +7,104 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Immortal : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Juggernaut Immortal"; }
-		}
+    internal class Immortal : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Juggernaut Immortal"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might"),
-					Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 80),
-					Spell.Buff("Enraged Defense", ret => Me.HealthPercent < 70),
-					Spell.Buff("Invincible", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 80),
+                    Spell.Buff("Enraged Defense", ret => Me.HealthPercent < 70),
+                    Spell.Buff("Invincible", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Retaliation"),
-					Spell.Cast("Crushing Blow"),
-					Spell.Cast("Force Scream"),
-					Spell.Cast("Aegis Assault", ret => Me.ActionPoints <= 7 || !Me.HasBuff("Aegis")),
-					Spell.Cast("Smash", ret => !Me.CurrentTarget.HasDebuff("Unsteady (Force)") && Targeting.ShouldPbaoe),
-					Spell.Cast("Backhand", ret => !Me.CurrentTarget.IsStunned),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("War Bringer")),
-					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9),
-					Spell.Cast("Assault"),
-					Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Retaliation"),
+                    Spell.Cast("Crushing Blow"),
+                    Spell.Cast("Force Scream"),
+                    Spell.Cast("Aegis Assault", ret => Me.ActionPoints <= 7 || !Me.HasBuff("Aegis")),
+                    Spell.Cast("Smash", ret => !Me.CurrentTarget.HasDebuff("Unsteady (Force)") && Targeting.ShouldPbaoe),
+                    Spell.Cast("Backhand", ret => !Me.CurrentTarget.IsStunned),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("War Bringer")),
+                    Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9),
+                    Spell.Cast("Assault"),
+                    Spell.Cast("Saber Throw", ret => Me.CurrentTarget.Distance >= 0.5f && Me.InCombat),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Chilling Scream", "Chilling Scream", 0, ret => Me.CurrentTarget.Distance <= 0.8f),
-						Spell.Cast("Smash"),
-						Spell.Cast("Crushing Blow", ret => Me.HasBuff("Aegis")),
-						Spell.Cast("Aegis Assault", ret => !Me.HasBuff("Aegis")),
-						Spell.Cast("Retaliation"),
-						Spell.Cast("Force Scream"),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Chilling Scream", "Chilling Scream", 0, ret => Me.CurrentTarget.Distance <= 0.8f),
+                        Spell.Cast("Smash"),
+                        Spell.Cast("Crushing Blow", ret => Me.HasBuff("Aegis")),
+                        Spell.Cast("Aegis Assault", ret => !Me.HasBuff("Aegis")),
+                        Spell.Cast("Retaliation"),
+                        Spell.Cast("Force Scream"),
+                        Spell.Cast("Sweeping Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Rage.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Rage.cs
@@ -7,95 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Rage : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Juggernaut Rage"; }
-		}
+    internal class Rage : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Juggernaut Rage"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Smash", ret => Me.BuffCount("Shockwave") == 3 && Me.HasBuff("Dominate") && Me.CurrentTarget.Distance <= 0.5f),
-					Spell.Cast("Force Choke", ret => Me.BuffCount("Shockwave") < 4),
-					Spell.Cast("Force Crush", ret => Me.BuffCount("Shockwave") < 4),
-					Spell.Cast("Obliterate", ret => Me.HasBuff("Shockwave")),
-					Spell.Cast("Force Scream", ret => Me.HasBuff("Battle Cry") || Me.ActionPoints >= 5),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Vicious Slash"),
-					Spell.Cast("Sundering Assault", ret => Me.CurrentTarget.DebuffCount("Armor Reduced") <= 5),
-					Spell.Cast("Assault"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Crush", ret => !Me.HasBuff("Enveloping Rage")),
+                    Spell.Cast("Force Scream", ret => !Me.HasBuff("Enveloping Rage")),
+                    Spell.Cast("Sundering Assault", ret => !Me.HasBuff("Enveloping Rage")),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Raging Burst", ret => Me.HasBuff("Dominate") && Me.BuffCount("Shockwave") < 3),
+                    Spell.Cast("Furious Strike", ret => Me.HasBuff("Cascading Power")),
+                    Spell.Cast("Obliterate"),
+                    Spell.Cast("Retaliation"),
+                    Spell.Cast("Vicious Throw"),
+                    Spell.Cast("Assault", ret => Me.Level <= 22 && Me.ActionPoints <= 5),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Smash"),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Saber Throw"),
+                        Spell.Cast("Obliterate"),
+                        Spell.Cast("Smash"),
+                        Spell.Cast("Chilling Scream"),
+                        Spell.Cast("Cyclone Slash"),
+                        Spell.Cast("Sweeping Assault")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Vengeance.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Juggernaut/Vengeance.cs
@@ -7,96 +7,97 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Vengeance : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Juggernaut Vengeance"; }
-		}
+    internal class Vengeance : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Juggernaut Vengeance"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Enraged Defense", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Enraged Defense", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Endure Pain", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Enrage", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 0.5f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Scream", ret => Me.BuffCount("Savagery") == 2),
-					Spell.Cast("Hew", ret => Me.HasBuff("Destroyer") || Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Shatter"),
-					Spell.Cast("Impale"),
-					Spell.Cast("Sundering Assault", ret => Me.ActionPoints <= 7),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 11),
-					Spell.Cast("Assault"),
-					Spell.Cast("Retaliation"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Impale"),
+                    Spell.Cast("Shatter"),
+                    Spell.Cast("Force Scream", ret => Me.BuffCount("Savagery") == 2),
+                    Spell.Cast("Vengeful Slam"),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Hew", ret => Me.HasBuff("Destroyer") || Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Sundering Assault", ret => Me.ActionPoints <= 7),
+                    Spell.Cast("Chilling Scream", ret => Me.ActionPoints >= 11),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Vengeful Slam"),
-						Spell.Cast("Smash"),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Sweeping Slash"),
+                        Spell.Cast("Vengeful Slam"),
+                        Spell.Cast("Shatter"),
+                        Spell.Cast("Impale"),
+                        Spell.Cast("Chilling Scream", ret => Me.ActionPoints <= 2)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Marauder/Annihilation.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Marauder/Annihilation.cs
@@ -7,114 +7,114 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Annihilation : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Marauder Annihilation"; }
-		}
+    internal class Annihilation : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Marauder Annihilation"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Deadly Saber", ret => !Me.HasBuff("Deadly Saber")),
-					Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
-					Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Deadly Saber", ret => !Me.HasBuff("Deadly Saber")),
+                    Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
+                    Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Annihilate"),
-					Spell.DoT("Force Rend", "Force Rend"),
-					Spell.DoT("Rupture", "Bleeding (Rupture)"),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Force Rend"),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Dual Saber Throw", ret => Me.HasBuff("Pulverize")),
-					Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Force Rend"),
-					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
-					Spell.Cast("Annihilate"),	
-					Spell.Cast("Force Rend"),
-					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Force Rend"),
-					Spell.Cast("Force Charge", ret => Me.ActionPoints <= 8),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Force Rend"),
-					Spell.Cast("Assault", ret => Me.ActionPoints < 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
-					Spell.Cast("Annihilate"),
-					Spell.Cast("Force Rend"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Annihilate"),
+                    Spell.DoT("Force Rend", "Force Rend"),
+                    Spell.DoT("Rupture", "Bleeding (Rupture)"),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Dual Saber Throw", ret => Me.HasBuff("Pulverize")),
+                    Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
+                    Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
+                    Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
+                    Spell.Cast("Force Charge", ret => Me.ActionPoints <= 8),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
+                    Spell.Cast("Assault", ret => Me.ActionPoints < 9 && Me.CurrentTarget.HasDebuff("Bleeding (Rupture)")),
+                    Spell.Cast("Annihilate"),
+                    Spell.Cast("Force Rend"),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-						Spell.Cast("Smash", ret => Me.CurrentTarget.HasDebuff("Bleeding (Rupture)") && Me.CurrentTarget.HasDebuff("Force Rend")),
-						Spell.DoT("Force Rend", "Force Rend"),
-						Spell.DoT("Rupture", "Bleeding (Rupture)"),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                        Spell.Cast("Smash", ret => Me.CurrentTarget.HasDebuff("Bleeding (Rupture)") && Me.CurrentTarget.HasDebuff("Force Rend")),
+                        Spell.DoT("Force Rend", "Force Rend"),
+                        Spell.DoT("Rupture", "Bleeding (Rupture)"),
+                        Spell.Cast("Sweeping Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Marauder/Carnage.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Marauder/Carnage.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Carnage : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Marauder Carnage"; }
-		}
+    internal class Carnage : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Marauder Carnage"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Force Camouflage", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
-					Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
-					Spell.Buff("Bloodthirst", ret => Me.BuffCount("Fury") > 29 && Me.InCombat),
-					Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Force Camouflage", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
+                    Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
+                    Spell.Buff("Bloodthirst", ret => Me.BuffCount("Fury") > 29 && Me.InCombat),
+                    Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
-					Spell.Cast("Ferocity"),
-					Spell.Cast("Devastating Blast", ret => Me.HasBuff("Ferocity")),
-					Spell.Cast("Gore", ret => Me.HasBuff("Ferocity")),
-					Spell.Cast("Vicious Throw", ret => Me.HasBuff("Ferocity")),
-					Spell.Cast("Ravage", ret => Me.HasBuff("Ferocity")),
-					Spell.Cast("Massacre", ret => !Me.HasBuff("Massacre")),
-					Spell.Cast("Dual Saber Throw", ret => !Me.HasBuff("Ferocity")),
-					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
-					//Temp removal as a test for significant DPS loss Spell.Cast("Force Scream", ret => Me.HasBuff("Execute")),
-					Spell.Cast("Assault", ret => Me.ActionPoints <= 5 && !Me.HasBuff("Ferocity")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						//Temp removal as a test for significant DPS loss Spell.Cast("Smash"),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
+                    Spell.Cast("Ferocity"),
+                    Spell.Cast("Devastating Blast", ret => Me.HasBuff("Ferocity")),
+                    Spell.Cast("Gore", ret => Me.HasBuff("Ferocity")),
+                    Spell.Cast("Vicious Throw", ret => Me.HasBuff("Ferocity")),
+                    Spell.Cast("Ravage", ret => Me.HasBuff("Ferocity")),
+                    Spell.Cast("Massacre", ret => !Me.HasBuff("Massacre")),
+                    Spell.Cast("Dual Saber Throw", ret => !Me.HasBuff("Ferocity")),
+                    Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6 && !Me.HasBuff("Ferocity")),
+                    //Temp removal as a test for significant DPS loss Spell.Cast("Force Scream", ret => Me.HasBuff("Execute")),
+                    Spell.Cast("Assault", ret => Me.ActionPoints <= 5 && !Me.HasBuff("Ferocity")),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                                                                                          //Temp removal as a test for significant DPS loss Spell.Cast("Smash"),
+                        Spell.Cast("Sweeping Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Marauder/Fury.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Marauder/Fury.cs
@@ -7,97 +7,97 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Fury : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Marauder Fury"; }
-		}
+    internal class Fury : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Marauder Fury"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unleash", ret => Me.IsStunned),
-					Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Frenzy", ret => Me.BuffCount("Fury") < 5),
-					Spell.Buff("Berserk", ret => Me.BuffCount("Fury") > 29),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unleash", ret => Me.IsStunned),
+                    Spell.Buff("Cloak of Pain", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Undying Rage", ret => Me.HealthPercent <= 20),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Frenzy"),
+                    Spell.Buff("Berserk"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Dual Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Charge", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Furious Strike"),
-					Spell.Cast("Force Crush"),
-					Spell.Cast("Obliterate"),
-					Spell.Cast("Raging Burst", ret => Me.HasBuff("Destruction") && Me.HasBuff("Dominate")),
-					Spell.Cast("Force Scream", ret => Me.HasBuff("Battle Cry") || Me.ActionPoints >= 5),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Dual Saber Throw"),
-					Spell.Cast("Vicious Slash", ret => Me.HasBuff("Berserk")),
-					Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6),
-					Spell.Cast("Assault", ret => Me.ActionPoints < 6),
+                    //Rotation
+                    Spell.Cast("Disruption", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Vicious Throw", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Raging Burst", ret => Me.HasBuff("Destruction") && Me.HasBuff("Dominate")),
+                    Spell.Cast("Furious Strike"),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Force Scream", ret => Me.HasBuff("Battle Cry") || Me.ActionPoints >= 5),
+                    Spell.Cast("Force Crush"),
+                    Spell.Cast("Vicious Slash", ret => Me.HasBuff("Berserk")),
+                    Spell.Cast("Obliterate", ret => Me.HasBuff("Berserk")),
+                    Spell.Cast("Battering Assault", ret => Me.ActionPoints <= 6),
+                    Spell.Cast("Assault", ret => (Me.ActionPoints < 4 || Me.Level <= 22)),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Smash", ret => Me.HasBuff("Destruction") && Me.HasBuff("Dominate")),
-						Spell.Cast("Sweeping Slash")
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Smash", ret => Me.HasBuff("Destruction") && Me.HasBuff("Dominate")),
+                        Spell.Cast("Sweeping Slash"),
+                        Spell.Cast("Dual Saber Throw")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Mercenary/Arsenal.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Mercenary/Arsenal.cs
@@ -7,101 +7,101 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Arsenal : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Mercenary Arsenal"; }
-		}
+    public class Arsenal : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Mercenary Arsenal"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
-					Spell.Buff("Supercharged Gas", ret => Me.BuffCount("Supercharge") == 10),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
+                    Spell.Buff("Supercharged Gas", ret => Me.BuffCount("Supercharge") == 10),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Kolto Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Emergency Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Rapid Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Rapid Shots", ret => Me.ResourcePercent() > 40),
-					Spell.Cast("Blazing Bolts", ret => Me.Level >= 57),
-					Spell.Cast("Unload", ret => Me.Level < 57),
-					Spell.Cast("Heatseeker Missiles", ret => Me.CurrentTarget.HasDebuff("Heat Signature")),
-					Spell.Cast("Rail Shot", ret => Me.BuffCount("Tracer Lock") == 5),
-					Spell.Cast("Electro Net"),
-					Spell.Cast("Priming Shot"),
-					Spell.Cast("Tracer Missile"),
-					Spell.Cast("Rapid Shots"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Kolto Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Emergency Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Rapid Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Buff("Thermal Sensor Override"),
-						Spell.Cast("Explosive Dart"),
-						Spell.Buff("Power Surge"),
-						Spell.CastOnGround("Death from Above"),
-						Spell.Cast("Fusion Missile", ret => Me.ResourcePercent() <= 10 && Me.HasBuff("Power Surge")),
-						Spell.CastOnGround("Sweeping Blasters", ret => Me.ResourcePercent() <= 10))
-					);
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Rapid Shots", ret => Me.ResourcePercent() > 40),
+                    Spell.Cast("Blazing Bolts", ret => Me.Level >= 57),
+                    Spell.Cast("Unload", ret => Me.Level < 57),
+                    Spell.Cast("Heatseeker Missiles", ret => Me.CurrentTarget.HasDebuff("Heat Signature")),
+                    Spell.Cast("Rail Shot", ret => Me.BuffCount("Tracer Lock") == 5),
+                    Spell.Cast("Electro Net"),
+                    Spell.Cast("Priming Shot"),
+                    Spell.Cast("Tracer Missile"),
+                    Spell.Cast("Rapid Shots"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Buff("Thermal Sensor Override"),
+                        Spell.Cast("Explosive Dart"),
+                        Spell.Buff("Power Surge"),
+                        Spell.CastOnGround("Death from Above"),
+                        Spell.Cast("Fusion Missile", ret => Me.ResourcePercent() <= 10 && Me.HasBuff("Power Surge")),
+                        Spell.CastOnGround("Sweeping Blasters", ret => Me.ResourcePercent() <= 10))
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Mercenary/Bodyguard.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Mercenary/Bodyguard.cs
@@ -7,114 +7,114 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Bodyguard : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Mercenary Bodyguard"; }
-		}
+    public class Bodyguard : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Mercenary Bodyguard"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Supercharged Gas", ret => Me.BuffCount("Supercharge") == 30 && Me.ResourcePercent() <= 60 && HealTarget != null && HealTarget.HealthPercent <= 80),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 70),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 40),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Supercharged Gas", ret => Me.BuffCount("Supercharge") == 30 && Me.ResourcePercent() <= 60 && HealTarget != null && HealTarget.HealthPercent <= 80),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 70),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 40),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Unload"),
-					Spell.Cast("Power Shot", ret => Me.ResourceStat >= 70),
-					Spell.Cast("Rapid Shots"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-					
-						//Legacy Heroic Moment Ability
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					
-						//BuffLog.Instance.LogTargetBuffs,
-						Spell.Cleanse("Cure"),
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Unload"),
+                    Spell.Cast("Power Shot", ret => Me.ResourceStat >= 70),
+                    Spell.Cast("Rapid Shots"),
 
-						//Buff Kolto Residue
-						new Decorator(ctx => HealTarget != null,
-							Spell.CastOnGround("Kolto Missile", on => HealTarget.Position, ret => HealTarget.HealthPercent < 60 && !HealTarget.HasBuff("Kolto Residue"))),
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-						//Free, so use it!
-						Spell.Heal("Emergency Scan", 80),
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
 
-						//Important Buffs to take advantage of
-						new Decorator(ctx => Tank != null,
-						Spell.CastOnGround("Kolto Missile", on => Tank.Position, ret => Me.HasBuff("Supercharged Gas") && Me.InCombat && !Tank.HasBuff("Charge Screen"))),
-						Spell.Heal("Rapid Scan", 80, ret => Me.HasBuff("Critical Efficiency")),
-						Spell.HealGround("Kolto Missile", ret => Me.HasBuff("Supercharged Gas")),
-						Spell.Heal("Healing Scan", 80, ret => Me.HasBuff("Supercharged Gas")),
+                        //Legacy Heroic Moment Ability
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
 
-						//Buff Tank
-						Spell.Heal("Kolto Shell", on => HealTarget, 100, ret => HealTarget != null && Me.InCombat && !HealTarget.HasBuff("Kolto Shell")),
+                        //BuffLog.Instance.LogTargetBuffs,
+                        Spell.Cleanse("Cure"),
 
-						//Single Target Priority
-						Spell.Heal("Healing Scan", 75),
-						Spell.Heal("Rapid Scan", 75),
+                        //Buff Kolto Residue
+                        new Decorator(ctx => HealTarget != null,
+                            Spell.CastOnGround("Kolto Missile", on => HealTarget.Position, ret => HealTarget.HealthPercent < 60 && !HealTarget.HasBuff("Kolto Residue"))),
 
-						//Filler
-						Spell.Heal("Rapid Shots", 95, ret => HealTarget != null && HealTarget.Name != Me.Name),
-						Spell.Heal("Rapid Shots", on => Tank, 100, ret => Tank != null && Me.InCombat)
-						));
-			}
-		}
-	}
+                        //Free, so use it!
+                        Spell.Heal("Emergency Scan", 80),
+
+                        //Important Buffs to take advantage of
+                        new Decorator(ctx => Tank != null,
+                        Spell.CastOnGround("Kolto Missile", on => Tank.Position, ret => Me.HasBuff("Supercharged Gas") && Me.InCombat && !Tank.HasBuff("Charge Screen"))),
+                        Spell.Heal("Rapid Scan", 80, ret => Me.HasBuff("Critical Efficiency")),
+                        Spell.HealGround("Kolto Missile", ret => Me.HasBuff("Supercharged Gas")),
+                        Spell.Heal("Healing Scan", 80, ret => Me.HasBuff("Supercharged Gas")),
+
+                        //Buff Tank
+                        Spell.Heal("Kolto Shell", on => HealTarget, 100, ret => HealTarget != null && Me.InCombat && !HealTarget.HasBuff("Kolto Shell")),
+
+                        //Single Target Priority
+                        Spell.Heal("Healing Scan", 75),
+                        Spell.Heal("Rapid Scan", 75),
+
+                        //Filler
+                        Spell.Heal("Rapid Shots", 95, ret => HealTarget != null && HealTarget.Name != Me.Name),
+                        Spell.Heal("Rapid Shots", on => Tank, 100, ret => Tank != null && Me.InCombat)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Mercenary/InnovativeOrdnance.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Mercenary/InnovativeOrdnance.cs
@@ -7,98 +7,98 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class InnovativeOrdnance : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Mercenary Innovative Ordnance"; }
-		}
+    public class InnovativeOrdnance : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Mercenary Innovative Ordnance"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Responsive Safeguards", ret => Me.HealthPercent <= 20),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					new Decorator(ret => Me.ResourcePercent() > 40,
-					new PrioritySelector(Spell.Cast("Rapid Shots"))),
-							
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Kolto Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Emergency Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Rapid Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
+                    new Decorator(ret => Me.ResourcePercent() > 40,
+                    new PrioritySelector(Spell.Cast("Rapid Shots"))),
 
-					//Rotation
-					Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.DoT("Incendiary Missile", "", 12000),
-					Spell.Cast("Thermal Detonator"),
-					Spell.Cast("Electro Net"),
-					Spell.Cast("Unload"),
-					Spell.Cast("Power Shot", ret => Me.HasBuff("Speed to Burn")),
-					Spell.Cast("Mag Shot", ret => Me.HasBuff("Innovative Particle Accelerator")),
-					Spell.Cast("Rapid Shots"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Kolto Shot", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Emergency Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Rapid Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Death from Above"),
-						Spell.Cast("Fusion Missle", ret => Me.HasBuff("Thermal Sensor Override")),
-						Spell.Cast("Explosive Dart"))
-					);
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Disabling Shot", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.DoT("Incendiary Missile", "", 12000),
+                    Spell.Cast("Thermal Detonator"),
+                    Spell.Cast("Electro Net"),
+                    Spell.Cast("Unload"),
+                    Spell.Cast("Power Shot", ret => Me.HasBuff("Speed to Burn")),
+                    Spell.Cast("Mag Shot", ret => Me.HasBuff("Innovative Particle Accelerator")),
+                    Spell.Cast("Rapid Shots"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Death from Above"),
+                        Spell.Cast("Fusion Missle", ret => Me.HasBuff("Thermal Sensor Override")),
+                        Spell.Cast("Explosive Dart"))
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Operative/Concealment.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Operative/Concealment.cs
@@ -9,122 +9,122 @@ using Targeting = DefaultCombat.Core.Targeting;
 
 namespace DefaultCombat.Routines
 {
-	public class Concealment : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Operative Concealment"; }
-		}
+    public class Concealment : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Operative Concealment"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination"),
-					Spell.Cast("Stealth", ret => !DefaultCombat.MovementDisabled && !Me.InCombat && !Me.HasBuff("Coordination"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination"),
+                    Spell.Cast("Stealth", ret => !DefaultCombat.MovementDisabled && !Me.InCombat && !Me.HasBuff("Coordination"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
-					Spell.Buff("Stim Boost", ret => Me.BuffCount("Tactical Advantage") < 2),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
+                    Spell.Buff("Stim Boost", ret => Me.BuffCount("Tactical Advantage") < 2),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Backstab", ret => Me.IsStealthed && Me.IsBehind(Me.CurrentTarget)),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Backstab", ret => Me.IsStealthed && Me.IsBehind(Me.CurrentTarget)),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Kolto Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Kolto Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
-					
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					new Decorator(ret => Me.ResourcePercent() < 60 && !AbilityManager.CanCast("Adrenaline Probe", Me),
-						new PrioritySelector(
-						Spell.Cast("Rifle Shot")
-							)),
-					new Decorator(
-						ret => (Me.CurrentTarget.HasDebuff("Poisoned (Acid Blade)") || Me.CurrentTarget.HasDebuff("Corrosive Dart")) && !Me.IsStealthed,
-						new PrioritySelector(
-						Spell.Cast("Volatile Substance"))),
-					new Decorator(
-						ret => Me.HasBuff("Tactical Advantage") &&	!Me.IsStealthed,
-						new PrioritySelector(
-						Spell.Cast("Laceration"))),
-					new Decorator(
-						ret => (!Me.CurrentTarget.HasDebuff("Corrosive Dart") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") <= 2) && !Me.IsStealthed,
-						new PrioritySelector(
-						Spell.Cast("Corrosive Dart"))),
-					new Decorator(
-						ret => !Me.HasBuff("Tactical Advantage") && !Me.IsStealthed,
-						new PrioritySelector(
-						Spell.Cast("Veiled Strike"))),
-					new Decorator(
-						ret => !Me.HasBuff("Tactical Advantage") && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && Me.IsBehind(Me.CurrentTarget),
-						new PrioritySelector(
-						Spell.Cast("Backstab"))),
-					new Decorator(
-						ret => !Me.HasBuff("Tactical Advantage") && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && !AbilityManager.CanCast("Backstab", Me.CurrentTarget) &&	!Me.IsStealthed,
-						new PrioritySelector(
-						Spell.Cast("Crippling Slice"))),
-					new Decorator(
-						ret => !Me.HasBuff("Tactical Advantage") && Me.EnergyPercent >= 87 && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && !AbilityManager.CanCast("Crippling Slice", Me.CurrentTarget) && !AbilityManager.CanCast("Backstab", Me.CurrentTarget) &&	!Me.IsStealthed,
-						new PrioritySelector(Spell.Cast("Overload Shot"))),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Fragmentation Grenade"),
-						Spell.Cast("Noxious Knives"),
-						Spell.Cast("Toxic Haze", ret => Me.HasBuff("Tactical Advantage"))
-					));
-			}
-		}
-	}
+                    //Solo Mode
+                    Spell.Cast("Kolto Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Kolto Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    new Decorator(ret => Me.ResourcePercent() < 60 && !AbilityManager.CanCast("Adrenaline Probe", Me),
+                        new PrioritySelector(
+                        Spell.Cast("Rifle Shot")
+                            )),
+                    new Decorator(
+                        ret => (Me.CurrentTarget.HasDebuff("Poisoned (Acid Blade)") || Me.CurrentTarget.HasDebuff("Corrosive Dart")) && !Me.IsStealthed,
+                        new PrioritySelector(
+                        Spell.Cast("Volatile Substance"))),
+                    new Decorator(
+                        ret => Me.HasBuff("Tactical Advantage") && !Me.IsStealthed,
+                        new PrioritySelector(
+                        Spell.Cast("Laceration"))),
+                    new Decorator(
+                        ret => (!Me.CurrentTarget.HasDebuff("Corrosive Dart") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") <= 2) && !Me.IsStealthed,
+                        new PrioritySelector(
+                        Spell.Cast("Corrosive Dart"))),
+                    new Decorator(
+                        ret => !Me.HasBuff("Tactical Advantage") && !Me.IsStealthed,
+                        new PrioritySelector(
+                        Spell.Cast("Veiled Strike"))),
+                    new Decorator(
+                        ret => !Me.HasBuff("Tactical Advantage") && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && Me.IsBehind(Me.CurrentTarget),
+                        new PrioritySelector(
+                        Spell.Cast("Backstab"))),
+                    new Decorator(
+                        ret => !Me.HasBuff("Tactical Advantage") && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && !AbilityManager.CanCast("Backstab", Me.CurrentTarget) && !Me.IsStealthed,
+                        new PrioritySelector(
+                        Spell.Cast("Crippling Slice"))),
+                    new Decorator(
+                        ret => !Me.HasBuff("Tactical Advantage") && Me.EnergyPercent >= 87 && !AbilityManager.CanCast("Veiled Strike", Me.CurrentTarget) && !AbilityManager.CanCast("Crippling Slice", Me.CurrentTarget) && !AbilityManager.CanCast("Backstab", Me.CurrentTarget) && !Me.IsStealthed,
+                        new PrioritySelector(Spell.Cast("Overload Shot"))),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Fragmentation Grenade"),
+                        Spell.Cast("Noxious Knives"),
+                        Spell.Cast("Toxic Haze", ret => Me.HasBuff("Tactical Advantage"))
+                    ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Operative/Lethality.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Operative/Lethality.cs
@@ -9,108 +9,108 @@ using Targeting = DefaultCombat.Core.Targeting;
 
 namespace DefaultCombat.Routines
 {
-	public class Lethality : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Operative Lethality"; }
-		}
+    public class Lethality : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Operative Lethality"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					
-					Spell.Buff("Coordination"),
-					Spell.Cast("Stealth", ret => !Me.InCombat && !Me.HasBuff("Coordination"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
-					Spell.Buff("Stim Boost", ret => !Me.HasBuff("Tactical Advantage") && Me.InCombat),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+                    Spell.Buff("Coordination"),
+                    Spell.Cast("Stealth", ret => !Me.InCombat && !Me.HasBuff("Coordination"))
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Holotraverse", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Hidden Strike", ret => Me.IsStealthed && Me.IsBehind(Me.CurrentTarget)),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60,
-						new PrioritySelector(
-							Spell.Cast("Overload Shot")
-							)),
-							
-					//Solo Mode
-					Spell.Cast("Kolto Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Kolto Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
-					
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Lethal Strike",	ret => Me.IsStealthed),
-					Spell.Cast("Corrosive Dart", ret =>	!Me.CurrentTarget.HasDebuff("Corrosive Dart") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") <= 2),
-					Spell.Cast("Corrosive Grenade",	ret => !Me.CurrentTarget.HasDebuff("Corrosive Grenade") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Grenade") <= 2),
-					Spell.Cast("Shiv", ret => Me.CurrentTarget.Distance <= Distance.Melee && Me.BuffCount("Tactical Advantage") < 2 || Me.BuffTimeLeft("Tactical Advantage") < 6),
-					Spell.Cast("Corrosive Assault",	ret =>	Me.HasBuff("Tactical Advantage") &&	Me.CurrentTarget.HasDebuff("Corrosive Dart") &&	Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
-					Spell.Cast("Lethal Strike",	ret =>	Me.CurrentTarget.HasDebuff("Corrosive Dart") &&	Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
-					Spell.Cast("Overload Shot",	ret =>	Me.EnergyPercent > 85),
-					Spell.Cast("Rifle Shot", ret =>	Me.EnergyPercent < 85),
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
+                    Spell.Buff("Stim Boost", ret => !Me.HasBuff("Tactical Advantage") && Me.InCombat),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Holotraverse", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Hidden Strike", ret => Me.IsStealthed && Me.IsBehind(Me.CurrentTarget)),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Corrosive Grenade", "Corrosive Grenade"),
-						Spell.Cast("Fragmentation Grenade"),
-						Spell.Cast("Noxious Knives"),
-						Spell.Cast("Toxic Haze", ret => Me.HasBuff("Tactical Advantage"))
-						));
-			}
-		}
-	}
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
+
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Overload Shot")
+                            )),
+
+                    //Solo Mode
+                    Spell.Cast("Kolto Infusion", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Kolto Probe", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Lethal Strike", ret => Me.IsStealthed),
+                    Spell.Cast("Corrosive Dart", ret => !Me.CurrentTarget.HasDebuff("Corrosive Dart") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") <= 2),
+                    Spell.Cast("Corrosive Grenade", ret => !Me.CurrentTarget.HasDebuff("Corrosive Grenade") || Me.CurrentTarget.DebuffTimeLeft("Corrosive Grenade") <= 2),
+                    Spell.Cast("Shiv", ret => Me.CurrentTarget.Distance <= Distance.Melee && Me.BuffCount("Tactical Advantage") < 2 || Me.BuffTimeLeft("Tactical Advantage") < 6),
+                    Spell.Cast("Corrosive Assault", ret => Me.HasBuff("Tactical Advantage") && Me.CurrentTarget.HasDebuff("Corrosive Dart") && Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
+                    Spell.Cast("Lethal Strike", ret => Me.CurrentTarget.HasDebuff("Corrosive Dart") && Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
+                    Spell.Cast("Overload Shot", ret => Me.EnergyPercent > 85),
+                    Spell.Cast("Rifle Shot", ret => Me.EnergyPercent < 85),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Corrosive Grenade", "Corrosive Grenade"),
+                        Spell.Cast("Fragmentation Grenade"),
+                        Spell.Cast("Noxious Knives"),
+                        Spell.Cast("Toxic Haze", ret => Me.HasBuff("Tactical Advantage"))
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Operative/Medicine.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Operative/Medicine.cs
@@ -7,96 +7,96 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Medicine : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Operative Medicine"; }
-		}
+    public class Medicine : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Operative Medicine"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination"),
-					Spell.Cast("Stealth", ret => !Me.InCombat && !Me.HasBuff("Coordination"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination"),
+                    Spell.Cast("Stealth", ret => !Me.InCombat && !Me.HasBuff("Coordination"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 20),
-					Spell.Buff("Stim Boost", ret => Me.EnergyPercent <= 70 && !Me.HasBuff("Tactical Advantage")),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 20),
+                    Spell.Buff("Stim Boost", ret => Me.EnergyPercent <= 70 && !Me.HasBuff("Tactical Advantage")),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Shiv", ret => Me.CurrentTarget.Distance <= Distance.Melee),
-					Spell.Cast("Explosive Probe", ret => Me.IsInCover()),
-					Spell.Cast("Hidden Strike", ret => Me.HasBuff("Stealth")),
-					Spell.Cast("Backstab"),
-					Spell.DoT("Corrosive Dart", "", 16000),
-					Spell.Cast("Overload Shot", ret => Me.EnergyPercent >= 70),
-					Spell.Cast("Rifle Shot"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					Spell.Heal("Surgical Probe", 30),
-					Spell.Heal("Recuperative Nanotech", on => Tank, 80, ret => Targeting.ShouldAoeHeal),
-					Spell.Heal("Kolto Probe", on => Tank, 100, ret => Tank != null && Tank.BuffCount("Kolto Probe") < 2 || Tank.BuffTimeLeft("Kolto Probe") < 6),
-					Spell.Heal("Kolto Infusion", 80,	ret => Me.BuffCount("Tactical Advantage") >= 2 && Me.EnergyPercent >= 60 && !HealTarget.HasBuff("Kolto Infusion")),
-					Spell.Heal("Surgical Probe", 80, ret => Me.BuffCount("Tactical Advantage") >= 2),
-					Spell.Heal("Kolto Injection", 80),
-					Spell.Cleanse("Toxin Scan"),
-					Spell.Heal("Kolto Probe", 90,	ret => HealTarget.BuffCount("Kolto Probe") < 2 || HealTarget.BuffTimeLeft("Kolto Probe") < 6),
-					Spell.Heal("Diagnostic Scan", 90)
-					);
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Shiv", ret => Me.CurrentTarget.Distance <= Distance.Melee),
+                    Spell.Cast("Explosive Probe", ret => Me.IsInCover()),
+                    Spell.Cast("Hidden Strike", ret => Me.HasBuff("Stealth")),
+                    Spell.Cast("Backstab"),
+                    Spell.DoT("Corrosive Dart", "", 16000),
+                    Spell.Cast("Overload Shot", ret => Me.EnergyPercent >= 70),
+                    Spell.Cast("Rifle Shot"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                    Spell.Heal("Surgical Probe", 30),
+                    Spell.Heal("Recuperative Nanotech", on => Tank, 80, ret => Targeting.ShouldAoeHeal),
+                    Spell.Heal("Kolto Probe", on => Tank, 100, ret => Tank != null && Tank.BuffCount("Kolto Probe") < 2 || Tank.BuffTimeLeft("Kolto Probe") < 6),
+                    Spell.Heal("Kolto Infusion", 80, ret => Me.BuffCount("Tactical Advantage") >= 2 && Me.EnergyPercent >= 60 && !HealTarget.HasBuff("Kolto Infusion")),
+                    Spell.Heal("Surgical Probe", 80, ret => Me.BuffCount("Tactical Advantage") >= 2),
+                    Spell.Heal("Kolto Injection", 80),
+                    Spell.Cleanse("Toxin Scan"),
+                    Spell.Heal("Kolto Probe", 90, ret => HealTarget.BuffCount("Kolto Probe") < 2 || HealTarget.BuffTimeLeft("Kolto Probe") < 6),
+                    Spell.Heal("Diagnostic Scan", 90)
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/AdvancedPrototype.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/AdvancedPrototype.cs
@@ -8,109 +8,109 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class AdvancedPrototype : RotationBase
-	{
-		public override string Name
-		{
-			get { return "PowerTech Advanced Prototype"; }
-		}
+    public class AdvancedPrototype : RotationBase
+    {
+        public override string Name
+        {
+            get { return "PowerTech Advanced Prototype"; }
+        }
 
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Shoulder Cannon"),
-					Spell.Buff("Thermal Sensor Override", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Explosive Fuel", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Shoulder Cannon"),
+                    Spell.Buff("Thermal Sensor Override", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Explosive Fuel", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Low Energy
-					new Decorator(ret => Me.ResourcePercent() < 50,
-						new PrioritySelector(
-							Spell.Cast("Rail Shot", ret => Me.HasBuff("Prototype Particle Accelerator")),
-							Spell.Cast("Rapid Shots")
-							)),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
-					Spell.Cast("Energy Burst", ret => Me.BuffCount("Energy Lode") == 4),
-					Spell.Cast("Rail Shot",	ret => Me.CurrentTarget.HasDebuff("Bleeding (Retractable Blade)") && Me.HasBuff("Prototype Particle Accelerator")),
-					Spell.DoT("Retractable Blade", "Bleeding (Retractable Blade)"),
-					Spell.Cast("Thermal Detonator"),
-					Spell.Cast("Rocket Punch"),
-					Spell.Cast("Magnetic Blast", ret => Me.Level >= 26),
-					Spell.Cast("Flame Burst", ret => Me.Level < 26),
+                    //Low Energy
+                    new Decorator(ret => Me.ResourcePercent() < 50,
+                        new PrioritySelector(
+                            Spell.Cast("Rail Shot", ret => Me.HasBuff("Prototype Particle Accelerator")),
+                            Spell.Cast("Rapid Shots")
+                            )),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Cast("Energy Burst", ret => Me.BuffCount("Energy Lode") == 4),
+                    Spell.Cast("Rail Shot", ret => Me.CurrentTarget.HasDebuff("Bleeding (Retractable Blade)") && Me.HasBuff("Prototype Particle Accelerator")),
+                    Spell.DoT("Retractable Blade", "Bleeding (Retractable Blade)"),
+                    Spell.Cast("Thermal Detonator"),
+                    Spell.Cast("Rocket Punch"),
+                    Spell.Cast("Magnetic Blast", ret => Me.Level >= 26),
+                    Spell.Cast("Flame Burst", ret => Me.Level < 26),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Targeting.ShouldAoe,
-						new PrioritySelector(
-							Spell.CastOnGround("Deadly Onslaught")
-							)),
-					new Decorator(ret => Targeting.ShouldPbaoe,
-						new PrioritySelector(
-							Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-							Spell.Cast("Searing Wave"),
-							Spell.Cast("Flame Sweep"),
-							Spell.Cast("Shatter Slug")
-							)));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Targeting.ShouldAoe,
+                        new PrioritySelector(
+                            Spell.CastOnGround("Deadly Onslaught")
+                            )),
+                    new Decorator(ret => Targeting.ShouldPbaoe,
+                        new PrioritySelector(
+                            Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                            Spell.Cast("Searing Wave"),
+                            Spell.Cast("Flame Sweep"),
+                            Spell.Cast("Shatter Slug")
+                            )));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/Pyrotech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/Pyrotech.cs
@@ -8,112 +8,112 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Pyrotech : RotationBase
-	{
-		public override string Name
-		{
-			get { return "PowerTech Pyrotech"; }
-		}
+    public class Pyrotech : RotationBase
+    {
+        public override string Name
+        {
+            get { return "PowerTech Pyrotech"; }
+        }
 
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Thermal Sensor Override", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Explosive Fuel", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 65),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Shoulder Cannon"),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Thermal Sensor Override", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Explosive Fuel", ret => Me.InCombat && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 65),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Shoulder Cannon"),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Low Energy
-					new Decorator(ret => Me.ResourcePercent() > 40,
-						new PrioritySelector(
-							Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Barrage")),
-							Spell.Cast("Rapid Shots")
-							)),
-							
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Low Energy
+                    new Decorator(ret => Me.ResourcePercent() > 40,
+                        new PrioritySelector(
+                            Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Barrage")),
+                            Spell.Cast("Rapid Shots")
+                            )),
 
-					//Rotation
-					Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
-					Spell.Cast("Searing Wave", ret => Me.BuffCount("Superheated Flamethrower") == 2),
-					Spell.DoT("Scorch", "Scorch"),
-					Spell.DoT("Incendiary Missile", "Burning (Incendiary Missile)"),
-					Spell.Cast("Rail Shot", ret => Me.HasBuff("Charged Gauntlets")),
-					Spell.Cast("Flaming Fist", ret => Me.HasBuff("Flame Barrage")),
-					Spell.Cast("Flaming Fist"),
-					Spell.Cast("Immolate"),
-					Spell.Cast("Flame Burst"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
+                    Spell.Cast("Searing Wave", ret => Me.BuffCount("Superheated Flamethrower") == 2),
+                    Spell.DoT("Scorch", "Scorch"),
+                    Spell.DoT("Incendiary Missile", "Burning (Incendiary Missile)"),
+                    Spell.Cast("Rail Shot", ret => Me.HasBuff("Charged Gauntlets")),
+                    Spell.Cast("Flaming Fist", ret => Me.HasBuff("Flame Barrage")),
+                    Spell.Cast("Flaming Fist"),
+                    Spell.Cast("Immolate"),
+                    Spell.Cast("Flame Burst"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Targeting.ShouldAoe,
-						new PrioritySelector(
-							Spell.DoT("Scorch", "Scorch"),
-							Spell.CastOnGround("Deadly Onslaught")
-							)),
-					new Decorator(ret => Targeting.ShouldPbaoe,
-						new PrioritySelector(
-							Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-							Spell.DoT("Scorch", "Scorch"),
-							Spell.Cast("Searing Wave"),
-							Spell.Cast("Flame Sweep"),
-							Spell.Cast("Shatter Slug")
-							)));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Targeting.ShouldAoe,
+                        new PrioritySelector(
+                            Spell.DoT("Scorch", "Scorch"),
+                            Spell.CastOnGround("Deadly Onslaught")
+                            )),
+                    new Decorator(ret => Targeting.ShouldPbaoe,
+                        new PrioritySelector(
+                            Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                            Spell.DoT("Scorch", "Scorch"),
+                            Spell.Cast("Searing Wave"),
+                            Spell.Cast("Flame Sweep"),
+                            Spell.Cast("Shatter Slug")
+                            )));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/PowerTech/ShieldTech.cs
@@ -7,107 +7,107 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class ShieldTech : RotationBase
-	{
-		public override string Name
-		{
-			get { return "PowerTech Shieldtech"; }
-		}
+    public class ShieldTech : RotationBase
+    {
+        public override string Name
+        {
+            get { return "PowerTech Shieldtech"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon"),
-					Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-				  Spell.Buff("Determination", ret => Me.IsStunned),
-					Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
-					Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 40),
-					Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Shoulder Cannon", ret => !Me.HasBuff("Shoulder Cannon")),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                  Spell.Buff("Determination", ret => Me.IsStunned),
+                    Spell.Buff("Vent Heat", ret => Me.ResourcePercent() >= 50),
+                    Spell.Buff("Energy Shield", ret => Me.HealthPercent <= 40),
+                    Spell.Buff("Kolto Overload", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Shoulder Cannon", ret => !Me.HasBuff("Shoulder Cannon")),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Jet Charge", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Jet Charge", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					new Decorator(ret => Me.ResourcePercent() > 40,
-						new PrioritySelector(
-							Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
-							Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-							Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
-							Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Surge")),
-							Spell.Cast("Rapid Shots"))),
-					    	Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-							Spell.CastOnGround("Oil Slick", ret => Me.CurrentTarget.BossOrGreater() && Me.CurrentTarget.Distance <= 0.8f),
-							Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
-							Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
-							Spell.Cast("Rocket Punch"),
-							Spell.Cast("Rail Shot"),
-							Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
-							Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
-							Spell.Cast("Flame Burst"),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Targeting.ShouldAoe,
-						new PrioritySelector(
-							Spell.CastOnGround("Deadly Onslaught")
-							)),
-					new Decorator(ret => Targeting.ShouldPbaoe,
-						new PrioritySelector(
-							Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-							Spell.Cast("Firestorm", ret => Me.Level >= 57),
-							Spell.Cast("Searing Wave", ret => Me.Level < 57),
-							Spell.Cast("Flame Sweep"),
-							Spell.Cast("Shatter Slug")
-							)));
-			}
-		}
-	}
+                    //Rotation
+                    new Decorator(ret => Me.ResourcePercent() > 40,
+                        new PrioritySelector(
+                            Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
+                            Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
+                            Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
+                            Spell.Cast("Flame Burst", ret => Me.HasBuff("Flame Surge")),
+                            Spell.Cast("Rapid Shots"))),
+                            Spell.Cast("Quell", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                            Spell.CastOnGround("Oil Slick", ret => Me.CurrentTarget.BossOrGreater() && Me.CurrentTarget.Distance <= 0.8f),
+                            Spell.Cast("Shoulder Cannon", ret => Me.HasBuff("Shoulder Cannon") && Me.CurrentTarget.BossOrGreater()),
+                            Spell.Cast("Heat Blast", ret => Me.BuffCount("Heat Screen") == 3),
+                            Spell.Cast("Rocket Punch"),
+                            Spell.Cast("Rail Shot"),
+                            Spell.Cast("Firestorm", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level >= 57),
+                            Spell.Cast("Searing Wave", ret => Me.HasBuff("Flame Engine") && Me.CurrentTarget.Distance <= 1f && Me.Level < 57),
+                            Spell.Cast("Flame Burst"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Targeting.ShouldAoe,
+                        new PrioritySelector(
+                            Spell.CastOnGround("Deadly Onslaught")
+                            )),
+                    new Decorator(ret => Targeting.ShouldPbaoe,
+                        new PrioritySelector(
+                            Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                            Spell.Cast("Firestorm", ret => Me.Level >= 57),
+                            Spell.Cast("Searing Wave", ret => Me.Level < 57),
+                            Spell.Cast("Flame Sweep"),
+                            Spell.Cast("Shatter Slug")
+                            )));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sage/Balance.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sage/Balance.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Balance : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sage Balance"; }
-		}
+    internal class Balance : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sage Balance"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Force Barrier", ret => Me.HealthPercent <= 20),
-					Spell.Buff("Force Armor", ret => !Me.HasBuff("Force Armor") && !Me.HasDebuff("Force-imbalance")),
-					Spell.Buff("Force Mend", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Mental Alacrity"),
-					Spell.Buff("Force Potency"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Force Barrier", ret => Me.HealthPercent <= 20),
+                    Spell.Buff("Force Armor", ret => !Me.HasBuff("Force Armor") && !Me.HasDebuff("Force-imbalance")),
+                    Spell.Buff("Force Mend", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Mental Alacrity"),
+                    Spell.Buff("Force Potency"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
-					
-					//Rotation
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Vanquish", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level >= 57),
-					Spell.Cast("Mind Crush", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level < 57),
-					Spell.DoT("Weaken Mind", "Weaken Mind"),
-					Spell.DoT("Sever Force", "Sever Force"),
-					Spell.CastOnGround("Force in Balance", ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
-					Spell.Cast("Force Serenity", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
-					Spell.Cast("Disturbance", ret => Me.BuffCount("Presence of Mind") == 4),
-					Spell.Cast("Telekinetic Throw", ret => Me.BuffCount("Presence of Mind") < 4),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Weaken Mind", "Weaken Mind"),
-						Spell.DoT("Sever Force", "Sever Force"),
-						Spell.CastOnGround("Force in Balance", ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
-						Spell.CastOnGround("Forcequake", ret => Me.CurrentTarget.HasDebuff("Overwhelmed (Mental)"))
-						));
-			}
-		}
-	}
+                    //Solo Mode
+                    Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+
+                    //Rotation
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Vanquish", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level >= 57),
+                    Spell.Cast("Mind Crush", ret => Me.BuffCount("Presence of Mind") == 4 && Me.Level < 57),
+                    Spell.DoT("Weaken Mind", "Weaken Mind"),
+                    Spell.DoT("Sever Force", "Sever Force"),
+                    Spell.CastOnGround("Force in Balance", ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
+                    Spell.Cast("Force Serenity", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
+                    Spell.Cast("Disturbance", ret => Me.BuffCount("Presence of Mind") == 4),
+                    Spell.Cast("Telekinetic Throw", ret => Me.BuffCount("Presence of Mind") < 4),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Weaken Mind", "Weaken Mind"),
+                        Spell.DoT("Sever Force", "Sever Force"),
+                        Spell.CastOnGround("Force in Balance", ret => Me.CurrentTarget.HasDebuff("Weaken Mind") && Me.CurrentTarget.HasDebuff("Sever Force")),
+                        Spell.CastOnGround("Forcequake", ret => Me.CurrentTarget.HasDebuff("Overwhelmed (Mental)"))
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sage/Seer.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sage/Seer.cs
@@ -7,129 +7,129 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Seer : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sage Seer"; }
-		}
+    internal class Seer : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sage Seer"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Force Potency", ret => Targeting.ShouldAoeHeal),
-					Spell.Buff("Mental Alacrity", ret => Targeting.ShouldAoeHeal),
-					Spell.Buff("Vindicate", ret => NeedForce()),
-					Spell.Buff("Force Mend", ret => Me.HealthPercent <= 75),
-					Spell.HoT("Force Armor", on => Me, 100, ret => Me.InCombat && !Me.HasDebuff("Force-imbalance")),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Force Potency", ret => Targeting.ShouldAoeHeal),
+                    Spell.Buff("Mental Alacrity", ret => Targeting.ShouldAoeHeal),
+                    Spell.Buff("Vindicate", ret => NeedForce()),
+                    Spell.Buff("Force Mend", ret => Me.HealthPercent <= 75),
+                    Spell.HoT("Force Armor", on => Me, 100, ret => Me.InCombat && !Me.HasDebuff("Force-imbalance")),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement 
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Forcequake", ret => Targeting.ShouldAoe),
-					Spell.DoT("Weaken Mind", "Weaken Mind"),
-					Spell.Cast("Mind Crush"),
-					Spell.Cast("Project"),
-					Spell.Cast("Telekinetic Throw"),
-					Spell.Cast("Disturbance"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement 
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-					//Legacy Heroic Moment Ability
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					
-					//Cleanse if needed 
-					Spell.Cleanse("Restoration"),
+                    //Rotation
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Forcequake", ret => Targeting.ShouldAoe),
+                    Spell.DoT("Weaken Mind", "Weaken Mind"),
+                    Spell.Cast("Mind Crush"),
+                    Spell.Cast("Project"),
+                    Spell.Cast("Telekinetic Throw"),
+                    Spell.Cast("Disturbance"),
 
-					//Emergency Heal (Insta-cast) 
-					Spell.Heal("Benevolence", 80, ret => Me.HasBuff("Altruism")),
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-					//AoE Healing 
-					new Decorator(ctx => Tank != null,
-						Spell.CastOnGround("Salvation", on => Tank.Position)),
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//Single Target Healing 
-					Spell.HoT("Force Armor", 90, ret => HealTarget != null && !HealTarget.HasDebuff("Force-imbalance")),
-					Spell.Heal("Healing Trance", 80),
+                    //Legacy Heroic Moment Ability
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
 
-					//Buff Tank 
-					Spell.HoT("Force Armor", on => Tank, 100,	ret => Tank != null && Tank.InCombat && !Tank.HasDebuff("Force-imbalance")),
-					Spell.Heal("Wandering Mend", onUnit => Tank, 100,	ret => Tank != null && Tank.InCombat && Me.BuffCount("Wandering Mend Charges") <= 1),
+                    //Cleanse if needed 
+                    Spell.Cleanse("Restoration"),
 
-					//Use Force Bending 
-					new Decorator(ret => Me.HasBuff("Conveyance"),
-						new PrioritySelector(
-							Spell.Heal("Healing Trance", 90),
-							Spell.Heal("Deliverance", 50)
-							)),
+                    //Emergency Heal (Insta-cast) 
+                    Spell.Heal("Benevolence", 80, ret => Me.HasBuff("Altruism")),
 
-					//Build Force Bending 
-					Spell.HoT("Rejuvenate", 80),
-					Spell.HoT("Rejuvenate", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat),
+                    //AoE Healing 
+                    new Decorator(ctx => Tank != null,
+                        Spell.CastOnGround("Salvation", on => Tank.Position)),
 
-					//Single Target Healing                   
-					Spell.Heal("Benevolence", 35),
-					Spell.Heal("Deliverance", 80)
-					);
-			}
-		}
+                    //Single Target Healing 
+                    Spell.HoT("Force Armor", 90, ret => HealTarget != null && !HealTarget.HasDebuff("Force-imbalance")),
+                    Spell.Heal("Healing Trance", 80),
 
-		private bool NeedForce()
-		{
-			if (Me.HasBuff("Resplendence") && Me.ForcePercent < 80 && !Me.HasBuff("Amnesty"))
-				return true;
-			return false;
-		}
-	}
+                    //Buff Tank 
+                    Spell.HoT("Force Armor", on => Tank, 100, ret => Tank != null && Tank.InCombat && !Tank.HasDebuff("Force-imbalance")),
+                    Spell.Heal("Wandering Mend", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat && Me.BuffCount("Wandering Mend Charges") <= 1),
+
+                    //Use Force Bending 
+                    new Decorator(ret => Me.HasBuff("Conveyance"),
+                        new PrioritySelector(
+                            Spell.Heal("Healing Trance", 90),
+                            Spell.Heal("Deliverance", 50)
+                            )),
+
+                    //Build Force Bending 
+                    Spell.HoT("Rejuvenate", 80),
+                    Spell.HoT("Rejuvenate", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat),
+
+                    //Single Target Healing                   
+                    Spell.Heal("Benevolence", 35),
+                    Spell.Heal("Deliverance", 80)
+                    );
+            }
+        }
+
+        private bool NeedForce()
+        {
+            if (Me.HasBuff("Resplendence") && Me.ForcePercent < 80 && !Me.HasBuff("Amnesty"))
+                return true;
+            return false;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sage/Telekinetics.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sage/Telekinetics.cs
@@ -7,98 +7,98 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Telekinetics : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sage Telekinetics"; }
-		}
+    internal class Telekinetics : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sage Telekinetics"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Force Potency", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Buff("Mental Alacrity", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Buff("Force Mend", ret => Me.HealthPercent <= 80),
-					Spell.HoT("Force Armor", on => Me, 99, ret => !Me.HasDebuff("Force-imbalance") && !Me.HasBuff("Force Armor")),
-					Spell.Buff("Vindicate", ret => Me.ForcePercent < 50 && !Me.HasDebuff("Weary")),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Force Potency", ret => Me.CurrentTarget.StrongOrGreater()),
+                    Spell.Buff("Mental Alacrity", ret => Me.CurrentTarget.StrongOrGreater()),
+                    Spell.Buff("Force Mend", ret => Me.HealthPercent <= 80),
+                    Spell.HoT("Force Armor", on => Me, 99, ret => !Me.HasDebuff("Force-imbalance") && !Me.HasBuff("Force Armor")),
+                    Spell.Buff("Vindicate", ret => Me.ForcePercent < 50 && !Me.HasDebuff("Weary")),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Rotation
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Weaken Mind", ret => !Me.CurrentTarget.HasDebuff("Weaken Mind")),
-					Spell.Cast("Turbulence", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
-					Spell.Cast("Mind Crush", ret => Me.HasBuff("Force Gust")),
-					Spell.Cast("Telekinetic Gust"),
-					Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
-					Spell.Cast("Telekinetic Burst", ret => Me.Level >= 57),
-					Spell.Cast("Disturbance", ret => Me.Level < 57),
-					Spell.Cast("Project"),
-					Spell.Cast("Telekinetic Throw"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Rejuvenate", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Benevolence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Force Mend", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
-						Spell.CastOnGround("Forcequake")
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Weaken Mind", ret => !Me.CurrentTarget.HasDebuff("Weaken Mind")),
+                    Spell.Cast("Turbulence", ret => Me.CurrentTarget.HasDebuff("Weaken Mind")),
+                    Spell.Cast("Mind Crush", ret => Me.HasBuff("Force Gust")),
+                    Spell.Cast("Telekinetic Gust"),
+                    Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
+                    Spell.Cast("Telekinetic Burst", ret => Me.Level >= 57),
+                    Spell.Cast("Disturbance", ret => Me.Level < 57),
+                    Spell.Cast("Project"),
+                    Spell.Cast("Telekinetic Throw"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Telekinetic Wave", ret => Me.HasBuff("Tidal Force")),
+                        Spell.CastOnGround("Forcequake")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Ruffian.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Ruffian.cs
@@ -7,104 +7,104 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Ruffian : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Scoundrel Ruffian"; }
-		}
+    internal class Ruffian : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Scoundrel Ruffian"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
-					Spell.Buff("Pugnacity", ret => !Me.HasBuff("Upper Hand") && Me.InCombat),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
+                    Spell.Buff("Pugnacity", ret => !Me.HasBuff("Upper Hand") && Me.InCombat),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60,
-						new PrioritySelector(
-							Spell.Cast("Flurry of Bolts")
-							)),
-							
-					//Solo Mode
-					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Brutal Shots", ret =>	Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb") && Me.HasBuff("Upper Hand")),
-					Spell.Cast("Sanguinary Shot",	ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb")),
-					Spell.DoT("Vital Shot", "Vital Shot"),
-					Spell.DoT("Shrap Bomb", "Shrap Bomb"),
-					Spell.Cast("Blaster Whip", ret => Me.BuffCount("Upper Hand") < 2 || Me.BuffTimeLeft("Upper Hand") < 6),
-					Spell.Cast("Point Blank Shot", ret => Me.Level >= 57),
-					Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget) && Me.Level < 57),
-					Spell.Cast("Quick Shot"),
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Flurry of Bolts")
+                            )),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Shrap Bomb", "Shrap Bomb"),
-						Spell.Cast("Thermal Grenade"),
-						Spell.Cast("Bushwhack", ret => !Me.HasBuff("Upper Hand")),
-						Spell.Cast("Lacerating Blast")
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Brutal Shots", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb") && Me.HasBuff("Upper Hand")),
+                    Spell.Cast("Sanguinary Shot", ret => Me.CurrentTarget.HasDebuff("Vital Shot") && Me.CurrentTarget.HasDebuff("Shrap Bomb")),
+                    Spell.DoT("Vital Shot", "Vital Shot"),
+                    Spell.DoT("Shrap Bomb", "Shrap Bomb"),
+                    Spell.Cast("Blaster Whip", ret => Me.BuffCount("Upper Hand") < 2 || Me.BuffTimeLeft("Upper Hand") < 6),
+                    Spell.Cast("Point Blank Shot", ret => Me.Level >= 57),
+                    Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget) && Me.Level < 57),
+                    Spell.Cast("Quick Shot"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Shrap Bomb", "Shrap Bomb"),
+                        Spell.Cast("Thermal Grenade"),
+                        Spell.Cast("Bushwhack", ret => !Me.HasBuff("Upper Hand")),
+                        Spell.Cast("Lacerating Blast")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Sawbones.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Sawbones.cs
@@ -7,123 +7,123 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Sawbones : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Scoundrel Sawbones"; }
-		}
+    public class Sawbones : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Scoundrel Sawbones"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest())
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest())
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 20),
-					Spell.Buff("Pugnacity", ret => Me.EnergyPercent <= 70 && Me.BuffCount("Upper Hand") < 3),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 20),
+                    Spell.Buff("Pugnacity", ret => Me.EnergyPercent <= 70 && Me.BuffCount("Upper Hand") < 3),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		//DPS 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-		//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-		//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)),
-					Spell.Cast("Blaster Whip"),
-					Spell.Cast("Vital Shot", ret => !Me.CurrentTarget.HasDebuff("Vital Shot")),
-					Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 70),
-					Spell.Cast("Flurry of Bolts"),
+        //DPS 
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
-		
-		//Healing 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					Spell.HealGround("Kolto Waves", ret => Targeting.ShouldAoeHeal),
-					Spell.Heal("Kolto Cloud", on => Tank, 80, ret => Tank != null && Targeting.ShouldAoeHeal),
-					Spell.Heal("Emergency Medpac", 90, ret => emergencyMedpac()),
-					Spell.Heal("Slow-release Medpac", on => Tank, 100, ret => Tank != null && tankSlowMedpac()),
-					Spell.Heal("Kolto Pack", 80, ret => Me.BuffCount("Upper Hand") >= 2 && Me.EnergyPercent >= 60 && !HealTarget.HasMyBuff("Kolto Pack")),
-					Spell.Heal("Underworld Medicine", 80),
-					Spell.Cleanse("Triage"),
-					Spell.Heal("Slow-release Medpac", 90, ret => targetSlowMedpac()),
-					Spell.Heal("Diagnostic Scan", 95)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public static bool tankSlowMedpac()
-		{
-			if (Targeting.Tank.BuffCount("Slow-release Medpac") < 2)
-				return true;
-			if (Targeting.Tank.BuffTimeLeft("Slow-release Medpac") < 3)
-				return true;
-			return false;
-		}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)),
+                    Spell.Cast("Blaster Whip"),
+                    Spell.Cast("Vital Shot", ret => !Me.CurrentTarget.HasDebuff("Vital Shot")),
+                    Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 70),
+                    Spell.Cast("Flurry of Bolts"),
 
-		public static bool targetSlowMedpac()
-		{
-			if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2)
-				return true;
-			if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") < 3)
-				return true;
-			return false;
-		}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-		public static bool emergencyMedpac()
-		{
-			if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") > 6)
-				return false;
-			if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2)
-				return false;
-			if (Me.BuffCount("Upper Hand") < 2)
-				return false;
-			return true;
-		}
-	}
+        //Healing 
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                    Spell.HealGround("Kolto Waves", ret => Targeting.ShouldAoeHeal),
+                    Spell.Heal("Kolto Cloud", on => Tank, 80, ret => Tank != null && Targeting.ShouldAoeHeal),
+                    Spell.Heal("Emergency Medpac", 90, ret => emergencyMedpac()),
+                    Spell.Heal("Slow-release Medpac", on => Tank, 100, ret => Tank != null && tankSlowMedpac()),
+                    Spell.Heal("Kolto Pack", 80, ret => Me.BuffCount("Upper Hand") >= 2 && Me.EnergyPercent >= 60 && !HealTarget.HasMyBuff("Kolto Pack")),
+                    Spell.Heal("Underworld Medicine", 80),
+                    Spell.Cleanse("Triage"),
+                    Spell.Heal("Slow-release Medpac", 90, ret => targetSlowMedpac()),
+                    Spell.Heal("Diagnostic Scan", 95)
+                    );
+            }
+        }
+
+        public static bool tankSlowMedpac()
+        {
+            if (Targeting.Tank.BuffCount("Slow-release Medpac") < 2)
+                return true;
+            if (Targeting.Tank.BuffTimeLeft("Slow-release Medpac") < 3)
+                return true;
+            return false;
+        }
+
+        public static bool targetSlowMedpac()
+        {
+            if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2)
+                return true;
+            if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") < 3)
+                return true;
+            return false;
+        }
+
+        public static bool emergencyMedpac()
+        {
+            if (Targeting.HealTarget.BuffTimeLeft("Slow-release Medpac") > 6)
+                return false;
+            if (Targeting.HealTarget.BuffCount("Slow-release Medpac") < 2)
+                return false;
+            if (Me.BuffCount("Upper Hand") < 2)
+                return false;
+            return true;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Scrapper.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Scoundrel/Scrapper.cs
@@ -7,102 +7,102 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Scrapper : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Scoundrel Scrapper"; }
-		}
+    public class Scrapper : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Scoundrel Scrapper"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest())
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !Rest.NeedRest())
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
-					Spell.Buff("Pugnacity", ret => Me.HasBuff("Upper Hand")),
-					Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
-					Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Cool Head", ret => Me.EnergyPercent <= 45),
+                    Spell.Buff("Pugnacity", ret => Me.HasBuff("Upper Hand")),
+                    Spell.Buff("Defense Screen", ret => Me.HealthPercent <= 75),
+                    Spell.Buff("Dodge", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60,
-						new PrioritySelector(
-							Spell.Cast("Flurry of Bolts")
-							)),
-							
-					//Solo Mode
-					Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)),
-					Spell.Cast("Sucker Punch", ret => Me.HasBuff("Upper Hand") && Me.CurrentTarget.HasDebuff("Vital Shot")),
-					Spell.DoT("Vital Shot", "Vital Shot"),
-					Spell.Cast("Blood Boiler"),
-					Spell.Cast("Bludgeon", ret => Me.Level >= 41),
-					Spell.Cast("Blaster Whip", ret => Me.Level < 41),
-					Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 75),
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Flurry of Bolts")
+                            )),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Diagnostic Scan", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Slow-release Medpac", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Kolto Pack", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Thermal Grenade"),
-						Spell.Cast("Bushwhack", ret => !Me.HasBuff("Upper Hand")),
-					  Spell.Cast("Lacerating Blast")
-					));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Back Blast", ret => Me.IsBehind(Me.CurrentTarget)),
+                    Spell.Cast("Sucker Punch", ret => Me.HasBuff("Upper Hand") && Me.CurrentTarget.HasDebuff("Vital Shot")),
+                    Spell.DoT("Vital Shot", "Vital Shot"),
+                    Spell.Cast("Blood Boiler"),
+                    Spell.Cast("Bludgeon", ret => Me.Level >= 41),
+                    Spell.Cast("Blaster Whip", ret => Me.Level < 41),
+                    Spell.Cast("Quick Shot", ret => Me.EnergyPercent >= 75),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Thermal Grenade"),
+                        Spell.Cast("Bushwhack", ret => !Me.HasBuff("Upper Hand")),
+                      Spell.Cast("Lacerating Blast")
+                    ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sentinel/Combat.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sentinel/Combat.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Combat : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sentinel Combat"; }
-		}
+    internal class Combat : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sentinel Combat"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Rebuke", ret => Me.HealthPercent <= 90),
-					Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Unity", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Valorous Call", ret => Me.BuffCount("Centering") < 5),
-					Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Rebuke", ret => Me.HealthPercent <= 90),
+                    Spell.Buff("Saber Reflect", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Unity", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Valorous Call", ret => Me.BuffCount("Centering") < 5),
+                    Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Rotation
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Dispatch", ret => Me.HasBuff("Hand of Justice") || Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Precision", ret => Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Blade Barrage", ret => Me.HasBuff("Precision")),
-					Spell.Cast("Clashing Blast", ret => Me.HasBuff("Opportune Attack") && Me.Level >= 57),
-					Spell.Cast("Lance"),
-					Spell.Cast("Blade Storm", ret => Me.HasBuff("Opportune Attack") && Me.Level < 57),
-					Spell.Cast("Blade Rush"),
-					Spell.Cast("Slash", ret => Me.ActionPoints >= 7 && Me.Level < 26),
-					Spell.Cast("Zealous Strike", ret => Me.ActionPoints <= 7),
-					Spell.Cast("Strike", ret => Me.ActionPoints <= 10),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Force Sweep"),
-						Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f),
-						Spell.Cast("Cyclone Slash")
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Dispatch", ret => Me.HasBuff("Hand of Justice") || Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Precision", ret => Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Blade Barrage", ret => Me.HasBuff("Precision")),
+                    Spell.Cast("Clashing Blast", ret => Me.HasBuff("Opportune Attack") && Me.Level >= 57),
+                    Spell.Cast("Lance"),
+                    Spell.Cast("Blade Storm", ret => Me.HasBuff("Opportune Attack") && Me.Level < 57),
+                    Spell.Cast("Blade Rush"),
+                    Spell.Cast("Slash", ret => Me.ActionPoints >= 7 && Me.Level < 26),
+                    Spell.Cast("Zealous Strike", ret => Me.ActionPoints <= 7),
+                    Spell.Cast("Strike", ret => Me.ActionPoints <= 10),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Force Sweep"),
+                        Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f),
+                        Spell.Cast("Cyclone Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sentinel/Concentration.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sentinel/Concentration.cs
@@ -7,94 +7,94 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Concentration : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sentinel Concentration"; }
-		}
+    internal class Concentration : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sentinel Concentration"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Rebuke", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 10),
-					Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Rebuke", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 10),
+                    Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Rotation
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Force Sweep", ret => Me.HasBuff("Singularity") && Me.HasBuff("Felling Blow")),
-					Spell.Cast("Force Exhaustion"),
-					Spell.Cast("Zealous Leap", ret => Me.HasBuff("Singularity")),
-					Spell.Cast("Blade Storm", ret => Me.HasBuff("Battle Cry") || Me.Energy >= 5),
-					Spell.Cast("Blade Barrage"),
-					Spell.Cast("Force Stasis"),
-					Spell.Cast("Slash", ret => Me.HasBuff("Zen")),
-					Spell.Cast("Zealous Strike"),
-					Spell.Cast("Strike"),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Force Sweep", ret => Me.HasBuff("Singularity") && Me.HasBuff("Felling Blow")),
+                    Spell.Cast("Force Exhaustion"),
+                    Spell.Cast("Zealous Leap", ret => Me.HasBuff("Singularity")),
+                    Spell.Cast("Blade Storm", ret => Me.HasBuff("Battle Cry") || Me.Energy >= 5),
+                    Spell.Cast("Blade Barrage"),
+                    Spell.Cast("Force Stasis"),
+                    Spell.Cast("Slash", ret => Me.HasBuff("Zen")),
+                    Spell.Cast("Zealous Strike"),
+                    Spell.Cast("Strike"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sentinel/Watchman.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sentinel/Watchman.cs
@@ -7,96 +7,96 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Watchman : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sentinel Watchman"; }
-		}
+    internal class Watchman : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sentinel Watchman"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Resolute", ret => Me.IsStunned),
-					Spell.Buff("Rebuke", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 10),
-					Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
-					Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Resolute", ret => Me.IsStunned),
+                    Spell.Buff("Rebuke", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Guarded by the Force", ret => Me.HealthPercent <= 10),
+                    Spell.Buff("Zen", ret => Me.BuffCount("Centering") > 29),
+                    Spell.Buff("Saber Ward", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Twin Saber Throw", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Force Leap", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Rotation
-					Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Buff("Valorous Call", ret => Me.BuffCount("Centering") < 5),
-					Spell.Buff("Overload Saber", ret => !Me.HasBuff("Overload Saber")),
-					Spell.DoT("Cauterize", "Burning (Cauterize)"),
-					Spell.DoT("Force Melt", "Burning (Force Melt)"),
-					Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Merciless Slash"),
-					Spell.Cast("Zealous Strike", ret => Me.ActionPoints <= 5),
-					Spell.Cast("Blade Barrage"),
-					Spell.Cast("Slash", ret => Me.Level < 41),
-					Spell.Cast("Strike", ret => Me.ActionPoints <= 10),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Force Sweep"),
-						Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f),
-						Spell.Cast("Cyclone Slash")
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Force Kick", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Buff("Valorous Call", ret => Me.BuffCount("Centering") < 5),
+                    Spell.Buff("Overload Saber", ret => !Me.HasBuff("Overload Saber")),
+                    Spell.DoT("Cauterize", "Burning (Cauterize)"),
+                    Spell.DoT("Force Melt", "Burning (Force Melt)"),
+                    Spell.Cast("Dispatch", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Merciless Slash"),
+                    Spell.Cast("Zealous Strike", ret => Me.ActionPoints <= 5),
+                    Spell.Cast("Blade Barrage"),
+                    Spell.Cast("Slash", ret => Me.Level < 41),
+                    Spell.Cast("Strike", ret => Me.ActionPoints <= 10),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Force Sweep"),
+                        Spell.Cast("Twin Saber Throw", ret => Me.CurrentTarget.Distance <= 3f),
+                        Spell.Cast("Cyclone Slash")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Shadow/Infiltration.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Shadow/Infiltration.cs
@@ -7,96 +7,98 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Infiltration : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Shadow Infiltration"; }
-		}
+    internal class Infiltration : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Shadow Infiltration"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor"),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor"),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Cast("Spinning Kick", ret => Me.IsStealthed),
-					Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Cast("Spinning Kick", ret => Me.IsStealthed),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Interrupts
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Low Slash", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
-					Spell.Cast("Force Potency"),
-					Spell.Cast("Force Breach", ret => Me.BuffCount("Breaching Shadows") == 3),
-					Spell.Cast("Shadow Strike", ret => Me.HasBuff("Stealth") || Me.HasBuff("Infiltration Tactics")),
-					Spell.Cast("Vaulting Slash", ret => Me.HasBuff("Stealth")),
-					Spell.Cast("Project", ret => Me.BuffCount("Circling Shadows") == 2),
-					Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Clairvoyant Strike"),
+                    //Interrupts
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Low Slash", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    Spell.Cast("Force Potency"),
+                    Spell.Cast("Force Breach", ret => Me.BuffCount("Breaching Shadows") == 3),
+                    Spell.Cast("Shadow Strike", ret => Me.HasBuff("Stealth") || Me.HasBuff("Infiltration Tactics")),
+                    Spell.Cast("Vaulting Slash", ret => Me.HasBuff("Stealth")),
+                    Spell.Cast("Project", ret => Me.BuffCount("Circling Shadows") == 2),
+                    Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Double Strike", ret => Me.ForcePercent >= 40),
+                    Spell.Cast("Clairvoyant Strike", ret => Me.Level >= 28 && Me.ForcePercent >= 40),
+                    Spell.Cast("Saber Strike", ret => Me.ForcePercent <= 40),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					Spell.Cast("Whirling Blow", ret => Me.ForcePercent >= 60 && Targeting.ShouldPbaoe)
-					);
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                    Spell.Cast("Whirling Blow", ret => Me.ForcePercent >= 60 && Targeting.ShouldPbaoe)
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Shadow/KeneticCombat.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Shadow/KeneticCombat.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class KeneticCombat : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Shadow Kenetic Combat"; }
-		}
+    internal class KeneticCombat : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Shadow Kenetic Combat"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor"),
-					Spell.Cast("Guard", on => Me.Companion,	ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Kinetic Ward", ret => Me.BuffCount("Kinetic Ward") <= 1 || Me.BuffTimeLeft("Kinetic Ward") < 3),
-					Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Force Potency"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Kinetic Ward", ret => Me.BuffCount("Kinetic Ward") <= 1 || Me.BuffTimeLeft("Kinetic Ward") < 3),
+                    Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Force Potency"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Rotation
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Saber Strike", ret => Me.ForcePercent < 25),
-					Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Cascading Debris", ret => Me.BuffCount("Harnessed Shadows") == 3),
-					Spell.Cast("Slow Time"),
-					Spell.Cast("Project", ret => Me.HasBuff("Particle Acceleration")),
-					Spell.Cast("Shadow Strike", ret => Me.HasBuff("Shadow Wrap")),
-					Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Force Breach"),
-					Spell.Cast("Double Strike"),
-					Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Saber Strike", ret => Me.ForcePercent < 25),
+                    Spell.Cast("Force Stun", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Cascading Debris", ret => Me.BuffCount("Harnessed Shadows") == 3),
+                    Spell.Cast("Slow Time"),
+                    Spell.Cast("Project", ret => Me.HasBuff("Particle Acceleration")),
+                    Spell.Cast("Shadow Strike", ret => Me.HasBuff("Shadow Wrap")),
+                    Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Force Breach"),
+                    Spell.Cast("Double Strike"),
+                    Spell.Cast("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Slow Time"),
-						Spell.Cast("Force Breach"),
-						Spell.Cast("Whirling Blow", ret => Me.ForcePercent >= 60 && Me.CurrentTarget.Distance <= 0.5f)
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Slow Time"),
+                        Spell.Cast("Force Breach"),
+                        Spell.Cast("Whirling Blow", ret => Me.ForcePercent >= 60 && Me.CurrentTarget.Distance <= 0.5f)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Shadow/Serenity.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Shadow/Serenity.cs
@@ -7,102 +7,102 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Serenity : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Shadow Serenity"; }
-		}
+    internal class Serenity : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Shadow Serenity"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force Valor"),
-					Spell.Cast("Guard", on => Me.Companion,	ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
-					Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force Valor"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard")),
+                    Spell.Buff("Stealth", ret => !Rest.KeepResting() && !DefaultCombat.MovementDisabled)
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Force of Will", ret => Me.IsStunned),
-					Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
-					Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Force Potency"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Force of Will", ret => Me.IsStunned),
+                    Spell.Buff("Battle Readiness", ret => Me.HealthPercent <= 85),
+                    Spell.Buff("Deflection", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Resilience", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Force Potency"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
-					Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Shadow Stride", ret => CombatHotkeys.EnableCharge && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
+                    Spell.Buff("Force Speed", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance >= 1f && Me.CurrentTarget.Distance <= 3f),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//Low Energy
-					Spell.Cast("Squelch", ret => Me.ForcePercent < 25 && Me.HasBuff("Force Strike")),
-					Spell.Cast("Saber Strike", ret => Me.ForcePercent < 25),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//Rotation
-					Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.CastOnGround("Force in Balance"),
-					Spell.Cast("Sever Force", ret => !Me.CurrentTarget.HasDebuff("Sever Force")),
-					Spell.DoT("Force Breach", "Crushed (Force Breach)"),
-					Spell.Cast("Squelch", ret => Me.HasBuff("Force Strike") && Me.Level >= 26),
-					Spell.Cast("Project", ret => Me.Level < 26),
-					Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Crush Spirit")),
-					Spell.Cast("Serenity Strike", ret => Me.HealthPercent <= 70),
-					Spell.Cast("Double Strike"),
-					Spell.Buff("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
+                    //Low Energy
+                    Spell.Cast("Squelch", ret => Me.ForcePercent < 25 && Me.HasBuff("Force Strike")),
+                    Spell.Cast("Saber Strike", ret => Me.ForcePercent < 25),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Rotation
+                    Spell.Cast("Mind Snap", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.CastOnGround("Force in Balance"),
+                    Spell.Cast("Sever Force", ret => !Me.CurrentTarget.HasDebuff("Sever Force")),
+                    Spell.DoT("Force Breach", "Crushed (Force Breach)"),
+                    Spell.Cast("Squelch", ret => Me.HasBuff("Force Strike") && Me.Level >= 26),
+                    Spell.Cast("Project", ret => Me.Level < 26),
+                    Spell.Cast("Spinning Strike", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Crush Spirit")),
+                    Spell.Cast("Serenity Strike", ret => Me.HealthPercent <= 70),
+                    Spell.Cast("Double Strike"),
+                    Spell.Buff("Force Speed", ret => Me.CurrentTarget.Distance >= 1.1f && Me.IsMoving && Me.InCombat),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Force Breach", "Crushed (Force Breach)"),
-						Spell.Cast("Sever Force", ret => !Me.CurrentTarget.HasDebuff("Sever Force")),
-						Spell.CastOnGround("Force in Balance"),
-						Spell.Cast("Whirling Blow", ret => Me.ForcePercent > 70)
-						));
-			}
-		}
-	}
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Force Breach", "Crushed (Force Breach)"),
+                        Spell.Cast("Sever Force", ret => !Me.CurrentTarget.HasDebuff("Sever Force")),
+                        Spell.CastOnGround("Force in Balance"),
+                        Spell.Cast("Whirling Blow", ret => Me.ForcePercent > 70)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sniper/Engineering.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sniper/Engineering.cs
@@ -7,120 +7,120 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Engineering : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sniper Engineering"; }
-		}
+    internal class Engineering : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sniper Engineering"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
-					Spell.Buff("Laze Target"),
-					Spell.Buff("Target Acquired"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 45),
+                    Spell.Buff("Laze Target"),
+                    Spell.Buff("Target Acquired"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 30,
-						new PrioritySelector(
-							Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
-							Spell.Cast("Rifle Shot")
-							)),
-
-					//Burn-ish
-					new Decorator(ret => Me.CurrentTarget.HealthPercent < 30,
-						new PrioritySelector(
-							Spell.Cast("Explosive Probe"),
-							Spell.Cast("Series of Shots"),
-							Spell.DoTGround("Plasma Probe", 8500),
-							Spell.DoT("Interrogation Probe", "Interrogation Probe"),
-							Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
-							Spell.Cast("EMP Discharge", ret => Me.CurrentTarget.HasDebuff("Interrogation Probe")),
-							Spell.Cast("Corrosive Dart", ret => !Me.CurrentTarget.HasDebuff("Marked [Physical]")),
-							Spell.Cast("Takedown"),
-							Spell.CastOnGround("Orbital Strike")
-							)),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.CastOnGround("Orbital Strike", ret => Me.HasBuff("Target Acquired")),
-					Spell.Cast("Explosive Probe"),
-					Spell.Cast("Series of Shots"),
-					Spell.DoTGround("Plasma Probe", 8500),
-					Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
-					Spell.DoT("Interrogation Probe", "Interrogation Probe"),
-					Spell.Cast("EMP Discharge", ret => Me.CurrentTarget.HasDebuff("Interrogation Probe")),
-					Spell.CastOnGround("Orbital Strike"),
-					Spell.DoT("Corrosive Dart", "Corrosive Dart"),
-					Spell.Cast("Fragmentation Grenade"),
-					Spell.Cast("Rifle Shot"),
-					Spell.Cast("Snipe"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 30,
+                        new PrioritySelector(
+                            Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
+                            Spell.Cast("Rifle Shot")
+                            )),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.DoTGround("Plasma Probe", 9000),
-						Spell.Cast("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
-						));
-			}
-		}
-	}
+                    //Burn-ish
+                    new Decorator(ret => Me.CurrentTarget.HealthPercent < 30,
+                        new PrioritySelector(
+                            Spell.Cast("Explosive Probe"),
+                            Spell.Cast("Series of Shots"),
+                            Spell.DoTGround("Plasma Probe", 8500),
+                            Spell.DoT("Interrogation Probe", "Interrogation Probe"),
+                            Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
+                            Spell.Cast("EMP Discharge", ret => Me.CurrentTarget.HasDebuff("Interrogation Probe")),
+                            Spell.Cast("Corrosive Dart", ret => !Me.CurrentTarget.HasDebuff("Marked [Physical]")),
+                            Spell.Cast("Takedown"),
+                            Spell.CastOnGround("Orbital Strike")
+                            )),
+
+
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.CastOnGround("Orbital Strike", ret => Me.HasBuff("Target Acquired")),
+                    Spell.Cast("Explosive Probe"),
+                    Spell.Cast("Series of Shots"),
+                    Spell.DoTGround("Plasma Probe", 8500),
+                    Spell.Cast("Fragmentation Grenade", ret => Me.HasBuff("Energy Overrides")),
+                    Spell.DoT("Interrogation Probe", "Interrogation Probe"),
+                    Spell.Cast("EMP Discharge", ret => Me.CurrentTarget.HasDebuff("Interrogation Probe")),
+                    Spell.CastOnGround("Orbital Strike"),
+                    Spell.DoT("Corrosive Dart", "Corrosive Dart"),
+                    Spell.Cast("Fragmentation Grenade"),
+                    Spell.Cast("Rifle Shot"),
+                    Spell.Cast("Snipe"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.DoTGround("Plasma Probe", 9000),
+                        Spell.Cast("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sniper/Marksmanship.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sniper/Marksmanship.cs
@@ -7,101 +7,101 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Marksmanship : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sniper Marksmanship"; }
-		}
+    internal class Marksmanship : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sniper Marksmanship"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 70),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 40),
-					Spell.Buff("Sniper Volley", ret => Me.EnergyPercent <= 60),
-					Spell.Buff("Entrench", ret => Me.CurrentTarget.StrongOrGreater() && Me.IsInCover()),
-					Spell.Buff("Laze Target"),
-					Spell.Buff("Target Acquired"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 70),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 40),
+                    Spell.Buff("Sniper Volley", ret => Me.EnergyPercent <= 60),
+                    Spell.Buff("Entrench", ret => Me.CurrentTarget.StrongOrGreater() && Me.IsInCover()),
+                    Spell.Buff("Laze Target"),
+                    Spell.Buff("Target Acquired"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Low Energy
-					new Decorator(ret => Me.EnergyPercent < 60,
-						new PrioritySelector(
-							Spell.Cast("Rifle Shot")
-							)),
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Followthrough"),
-					Spell.Cast("Penetrating Blasts", ret => Me.Level >= 26),
-					Spell.Cast("Series of Shots", ret => Me.Level < 26),
-					Spell.DoT("Corrosive Dart", "Corrosive Dart"),
-					Spell.Cast("Ambush", ret => Me.BuffCount("Zeroing Shots") == 2),
-					Spell.Cast("Takedown", ret => Me.CurrentTarget.HealthPercent <= 30),
-					Spell.Cast("Snipe"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Energy
+                    new Decorator(ret => Me.EnergyPercent < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Rifle Shot")
+                            )),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.Cast("Fragmentation Grenade"),
-						Spell.CastOnGround("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Followthrough"),
+                    Spell.Cast("Penetrating Blasts", ret => Me.Level >= 26),
+                    Spell.Cast("Series of Shots", ret => Me.Level < 26),
+                    Spell.DoT("Corrosive Dart", "Corrosive Dart"),
+                    Spell.Cast("Ambush", ret => Me.BuffCount("Zeroing Shots") == 2),
+                    Spell.Cast("Takedown", ret => Me.CurrentTarget.HealthPercent <= 30),
+                    Spell.Cast("Snipe"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.Cast("Fragmentation Grenade"),
+                        Spell.CastOnGround("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sniper/Virulence.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sniper/Virulence.cs
@@ -7,99 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Virulence : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sniper Virulence"; }
-		}
+    internal class Virulence : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sniper Virulence"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Escape", ret => Me.IsStunned),
-					Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 50),
-					Spell.Buff("Laze Target", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Cast("Target Acquired", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Escape", ret => Me.IsStunned),
+                    Spell.Buff("Shield Probe", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Evasion", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Adrenaline Probe", ret => Me.EnergyPercent <= 50),
+                    Spell.Buff("Laze Target", ret => Me.CurrentTarget.StrongOrGreater()),
+                    Spell.Cast("Target Acquired", ret => Me.CurrentTarget.StrongOrGreater()),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Low Energy
-					Spell.Cast("Rifle Shot", ret => Me.EnergyPercent < 60),
 
-					//Rotation
-					Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.DoT("Corrosive Dart", "Corrosive Dart"),
-					Spell.DoT("Corrosive Grenade", "Corrosive Grenade"),
-					Spell.Cast("Weakening Blast",	ret => Me.CurrentTarget.HasDebuff("Corrosive Dart") && Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
-					Spell.Cast("Cull",	ret =>	Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") > 3 && Me.CurrentTarget.DebuffTimeLeft("Corrosive Grenade") > 3),
-					Spell.Cast("Takedown", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Lethal Takedown")),
-					Spell.Cast("Series of Shots"),
-					Spell.Cast("Lethal Shot"),
-					Spell.Cast("Snipe"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Low Energy
+                    Spell.Cast("Rifle Shot", ret => Me.EnergyPercent < 60),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
-						Spell.Cast("Fragmentation Grenade"),
-						Spell.DoT("Corrosive Dart", "Corrosive Dart"),
-						Spell.Cast("Corrosive Grenade",	ret => Me.CurrentTarget.HasDebuff("Corrosive Dart") && !Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
-						Spell.CastOnGround("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    Spell.Cast("Distraction", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.DoT("Corrosive Dart", "Corrosive Dart"),
+                    Spell.DoT("Corrosive Grenade", "Corrosive Grenade"),
+                    Spell.Cast("Weakening Blast", ret => Me.CurrentTarget.HasDebuff("Corrosive Dart") && Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
+                    Spell.Cast("Cull", ret => Me.CurrentTarget.DebuffTimeLeft("Corrosive Dart") > 3 && Me.CurrentTarget.DebuffTimeLeft("Corrosive Grenade") > 3),
+                    Spell.Cast("Takedown", ret => Me.CurrentTarget.HealthPercent <= 30 || Me.HasBuff("Lethal Takedown")),
+                    Spell.Cast("Series of Shots"),
+                    Spell.Cast("Lethal Shot"),
+                    Spell.Cast("Snipe"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Buff("Crouch", ret => !Me.IsInCover() && !Me.IsMoving),
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Orbital Strike", ret => Me.IsInCover() && Me.EnergyPercent > 30),
+                        Spell.Cast("Fragmentation Grenade"),
+                        Spell.DoT("Corrosive Dart", "Corrosive Dart"),
+                        Spell.Cast("Corrosive Grenade", ret => Me.CurrentTarget.HasDebuff("Corrosive Dart") && !Me.CurrentTarget.HasDebuff("Corrosive Grenade")),
+                        Spell.CastOnGround("Suppressive Fire", ret => Me.IsInCover() && Me.EnergyPercent > 10)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Corruption.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Corruption.cs
@@ -7,128 +7,128 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Corruption : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sorcerer Corruption"; }
-		}
+    internal class Corruption : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sorcerer Corruption"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-        
-        			Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Recklessness", ret => Targeting.ShouldAoeHeal),
-					Spell.Buff("Consuming Darkness", ret => NeedForce()),
-					Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent < 50),
-					Spell.HoT("Static Barrier", on => Me, 100, ret => Me.InCombat && !Me.HasDebuff("Deionized")),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-				);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
+                    Spell.Buff("Recklessness", ret => Targeting.ShouldAoeHeal),
+                    Spell.Buff("Consuming Darkness", ret => NeedForce()),
+                    Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent < 50),
+                    Spell.HoT("Static Barrier", on => Me, 100, ret => Me.InCombat && !Me.HasDebuff("Deionized")),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                );
+            }
+        }
 
-					//Rotation
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Force Lightning"),
-					Spell.Cast("Crushing Darkness"),
-					Spell.Cast("Affliction", ret => !Me.CurrentTarget.HasDebuff("Affliction")),
-					Spell.Cast("Lightning Strike"),
-					Spell.Cast("Shock"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-					//Legacy Heroic Moment Ability
-					Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-					Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-					
-					//BuffLog.Instance.LogTargetBuffs
+                    //Rotation
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Force Lightning"),
+                    Spell.Cast("Crushing Darkness"),
+                    Spell.Cast("Affliction", ret => !Me.CurrentTarget.HasDebuff("Affliction")),
+                    Spell.Cast("Lightning Strike"),
+                    Spell.Cast("Shock"),
 
-					//Cleanse if needed
-					Spell.Cleanse("Purge"),
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
-					//Emergency Heal (Insta-cast)
-					Spell.Heal("Dark Heal", 80, ret => Me.HasBuff("Dark Concentration")),
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//Buff Tank
-					Spell.HoT("Static Barrier", on => Tank, 100, ret => Tank !=null && Tank.InCombat),
-					Spell.Heal("Roaming Mend", onUnit => Tank, 100,	ret => Tank != null && Tank.InCombat && Me.BuffCount("Roaming Mend Charges") <= 1),
+                    //Legacy Heroic Moment Ability
+                    Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                    Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
 
-					//Single Target Healing
-					Spell.HoT("Static Barrier", 99, ret => HealTarget != null && !HealTarget.HasDebuff("Deionized")),
-          			Spell.Heal("Innervate", 80),
+                    //BuffLog.Instance.LogTargetBuffs
 
-					//Use Force Bending
-					new Decorator(ret => Me.HasBuff("Force Bending"),
-						new PrioritySelector(
-							Spell.Heal("Innervate", 90),
-							Spell.Heal("Dark Infusion", 50)
-							)),
+                    //Cleanse if needed
+                    Spell.Cleanse("Purge"),
 
-					//Build Force Bending
-					Spell.HoT("Resurgence", 80),
-					Spell.HoT("Resurgence", on => Tank, 100, ret => Tank != null && Tank.InCombat),
+                    //Emergency Heal (Insta-cast)
+                    Spell.Heal("Dark Heal", 80, ret => Me.HasBuff("Dark Concentration")),
 
-					//AoE Healing 
-					new Decorator(ctx => Tank != null,
-						Spell.CastOnGround("Revivification", on => Tank.Position)),
+                    //Buff Tank
+                    Spell.HoT("Static Barrier", on => Tank, 100, ret => Tank != null && Tank.InCombat),
+                    Spell.Heal("Roaming Mend", onUnit => Tank, 100, ret => Tank != null && Tank.InCombat && Me.BuffCount("Roaming Mend Charges") <= 1),
 
-					//Single Target Healing                  
-					Spell.Heal("Dark Heal", 35),
-					Spell.Heal("Dark Infusion", 80));
-			}
-		}
+                    //Single Target Healing
+                    Spell.HoT("Static Barrier", 99, ret => HealTarget != null && !HealTarget.HasDebuff("Deionized")),
+                      Spell.Heal("Innervate", 80),
 
-		private bool NeedForce()
-		{
-			if (Me.HasBuff("Force Surge") && Me.ForcePercent < 80 && !Me.HasBuff("Reverse Corruptions"))
-				return true;
-			return false;
-		}
-	}
+                    //Use Force Bending
+                    new Decorator(ret => Me.HasBuff("Force Bending"),
+                        new PrioritySelector(
+                            Spell.Heal("Innervate", 90),
+                            Spell.Heal("Dark Infusion", 50)
+                            )),
+
+                    //Build Force Bending
+                    Spell.HoT("Resurgence", 80),
+                    Spell.HoT("Resurgence", on => Tank, 100, ret => Tank != null && Tank.InCombat),
+
+                    //AoE Healing 
+                    new Decorator(ctx => Tank != null,
+                        Spell.CastOnGround("Revivification", on => Tank.Position)),
+
+                    //Single Target Healing                  
+                    Spell.Heal("Dark Heal", 35),
+                    Spell.Heal("Dark Infusion", 80));
+            }
+        }
+
+        private bool NeedForce()
+        {
+            if (Me.HasBuff("Force Surge") && Me.ForcePercent < 80 && !Me.HasBuff("Reverse Corruptions"))
+                return true;
+            return false;
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Lightning.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Lightning.cs
@@ -7,97 +7,99 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Lightning : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sorcerer Lightning"; }
-		}
+    internal class Lightning : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sorcerer Lightning"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Recklessness", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Buff("Polarity Shift", ret => Me.CurrentTarget.StrongOrGreater()),
-					Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent <= 80),
-					Spell.HoT("Static Barrier", on => Me, 99, ret => !Me.HasDebuff("Deionized") && !Me.HasBuff("Static Barrier")),
-					Spell.Buff("Consuming Darkness", ret => Me.ForcePercent < 50 && !Me.HasDebuff("Weary")),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
+                    Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent <= 80),
+                    Spell.HoT("Static Barrier", on => Me, 99, ret => !Me.HasDebuff("Deionized") && !Me.HasBuff("Static Barrier")),
+                    Spell.Buff("Consuming Darkness", ret => Me.ForcePercent < 50 && !Me.HasDebuff("Weary")),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
 
-					//Rotation
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Thundering Blast"),
-					Spell.Cast("Affliction", ret => !Me.CurrentTarget.HasDebuff("Affliction")),
-					Spell.Cast("Crushing Darkness", ret => Me.HasBuff("Force Flash")),
-					Spell.Cast("Lightning Flash"),
-					Spell.Cast("Shock", ret => Me.CurrentTarget.HasDebuff("Crushed (Crushing Darkness)")),
-					Spell.Cast("Chain Lightning", ret => Me.HasBuff("Focal Lightning")),
-					Spell.Cast("Lightning Bolt"),
-					Spell.Cast("Force Lightning", ret => Me.HasBuff("Lightning Barrage")),
-					Spell.Cast("Lightning Strike"),
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Solo Mode
+                    Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.Cast("Chain Lightning", ret => Me.HasBuff("Lightning Storm")),
-						Spell.CastOnGround("Force Storm")
-						));
-			}
-		}
-	}
+                    //Opener
+                    Spell.Cast("Crushing Darkness", ret => Me.CurrentTarget.HealthPercent >= 90),
+                    Spell.Buff("Polarity Shift", ret => Me.CurrentTarget.HealthPercent >= 90),
+                    Spell.Cast("Affliction", ret => Me.CurrentTarget.HealthPercent >= 90 && Me.CurrentTarget.HasDebuff("Affliction")),
+                    Spell.Buff("Unlimited Power", ret => Me.CurrentTarget.HealthPercent >= 90),
+                    Spell.Buff("Recklessness", ret => Me.CurrentTarget.HealthPercent >= 90),
+
+                    //Rotation
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Thundering Blast"),
+                    Spell.Cast("Crushing Darkness", ret => Me.HasBuff("Force Flash")),
+                    Spell.Cast("Lightning Flash"),
+                    Spell.Cast("Shock", ret => Me.CurrentTarget.HasDebuff("Crushed (Crushing Darkness)")),
+                    Spell.Cast("Chain Lightning", ret => Me.HasBuff("Focal Lightning")),
+                    Spell.Cast("Lightning Bolt"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.Cast("Chain Lightning"),
+                        Spell.CastOnGround("Force Storm")
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Madness.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Sorcerer/Madness.cs
@@ -7,104 +7,104 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	internal class Madness : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Sorcerer Madness"; }
-		}
+    internal class Madness : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Sorcerer Madness"; }
+        }
 
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power")
+                    );
+            }
+        }
 
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
           Spell.Buff("Unbreakable Will", ret => Me.IsStunned),
-					Spell.Buff("Force Barrier", ret => Me.HealthPercent <= 20),
-					Spell.Buff("Static Barrier", ret => !Me.HasBuff("Static Barrier") && !Me.HasDebuff("Deionized")),
-					Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent <= 50),
-					Spell.Buff("Polarity Shift"),
-					Spell.Buff("Recklessness"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+                    Spell.Buff("Force Barrier", ret => Me.HealthPercent <= 20),
+                    Spell.Buff("Static Barrier", ret => !Me.HasBuff("Static Barrier") && !Me.HasDebuff("Deionized")),
+                    Spell.Buff("Unnatural Preservation", ret => Me.HealthPercent <= 50),
+                    Spell.Buff("Polarity Shift"),
+                    Spell.Buff("Recklessness"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-					//Movement
-					CombatMovement.CloseDistance(Distance.Ranged),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Solo Mode
-					Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
-					Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
-					Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
-					
-					//Rotation
-					Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Demolish", ret => Me.BuffCount("Wrath") == 4),
-					Spell.DoT("Affliction", "Affliction"),
-					Spell.DoT("Creeping Terror", "Creeping Terror"),
-					Spell.CastOnGround("Death Field",	ret => Me.CurrentTarget.HasDebuff("Affliction") && Me.CurrentTarget.HasDebuff("Creeping Terror")),
-					Spell.Cast("Force Leach", ret => Me.CurrentTarget.HasDebuff("Affliction")),
-					Spell.Cast("Lightning Strike", ret => Me.BuffCount("Wrath") == 4),
-					Spell.Cast("Crushing Darkness", ret => Me.HasBuff("Force Flash")),
-					Spell.Cast("Force Lightning", ret => Me.BuffCount("Wrath") < 4),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Ranged),
+
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+                    //Solo Mode
+                    Spell.Cast("Resurgence", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 70),
+                    Spell.Cast("Dark Heal", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 60),
+                    Spell.Cast("Unnatural Preservation", ret => CombatHotkeys.EnableSolo && Me.HealthPercent <= 50),
+
+                    //Rotation
+                    Spell.Cast("Jolt", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Electrocute", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Demolish", ret => Me.BuffCount("Wrath") == 4),
+                    Spell.DoT("Affliction", "Affliction"),
+                    Spell.DoT("Creeping Terror", "Creeping Terror"),
+                    Spell.CastOnGround("Death Field", ret => Me.CurrentTarget.HasDebuff("Affliction") && Me.CurrentTarget.HasDebuff("Creeping Terror")),
+                    Spell.Cast("Force Leach", ret => Me.CurrentTarget.HasDebuff("Affliction")),
+                    Spell.Cast("Lightning Strike", ret => Me.BuffCount("Wrath") == 4),
+                    Spell.Cast("Crushing Darkness", ret => Me.HasBuff("Force Flash")),
+                    Spell.Cast("Force Lightning", ret => Me.BuffCount("Wrath") < 4),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
 
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.DoT("Affliction", "Affliction"),
-						Spell.DoT("Creeping Terror", "Creeping Terror"),
-						Spell.CastOnGround("Death Field",	ret => Me.CurrentTarget.HasDebuff("Affliction") && Me.CurrentTarget.HasDebuff("Creeping Terror")),
-						Spell.CastOnGround("Force Storm", ret => Me.CurrentTarget.HasDebuff("Overwhelmed (Mental)"))
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.DoT("Affliction", "Affliction"),
+                        Spell.DoT("Creeping Terror", "Creeping Terror"),
+                        Spell.CastOnGround("Death Field", ret => Me.CurrentTarget.HasDebuff("Affliction") && Me.CurrentTarget.HasDebuff("Creeping Terror")),
+                        Spell.CastOnGround("Force Storm", ret => Me.CurrentTarget.HasDebuff("Overwhelmed (Mental)"))
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Vanguard/Plasmatech.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Vanguard/Plasmatech.cs
@@ -7,97 +7,97 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Plasmatech : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Vanguard Plasmatech"; }
-		}
+    public class Plasmatech : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Vanguard Plasmatech"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Battle Focus"),
-					Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() <= 50),
-					Spell.Buff("Reserve Powercell"),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Battle Focus"),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() <= 50),
+                    Spell.Buff("Reserve Powercell"),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-				
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					new Decorator(ret => Me.ResourcePercent() < 60,
-						new PrioritySelector(
-							Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator")),
-							Spell.Cast("Hammer Shot")
-							)),
-					Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("High Impact Bolt"),
-					Spell.Cast("Stockstrike", ret => Me.CurrentTarget.Distance <= .4f),
-					Spell.Cast("Assault Plastique"),
-					Spell.DoT("Incendiary Round", "", 12000),
-					Spell.Cast("Shockstrike"),
-					Spell.Cast("Ion Pulse"),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Artillery Blitz"),
-						Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
-						Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
-						Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
-						));
-			}
-		}
-	}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+                    //Rotation
+                    new Decorator(ret => Me.ResourcePercent() < 60,
+                        new PrioritySelector(
+                            Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Ionic Accelerator")),
+                            Spell.Cast("Hammer Shot")
+                            )),
+                    Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("High Impact Bolt"),
+                    Spell.Cast("Stockstrike", ret => Me.CurrentTarget.Distance <= .4f),
+                    Spell.Cast("Assault Plastique"),
+                    Spell.DoT("Incendiary Round", "", 12000),
+                    Spell.Cast("Shockstrike"),
+                    Spell.Cast("Ion Pulse"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Artillery Blitz"),
+                        Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
+                        Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
+                        Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Vanguard/ShieldSpecialist.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Vanguard/ShieldSpecialist.cs
@@ -7,103 +7,103 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class ShieldSpecialist : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Vanguard Shield Specialist"; }
-		}
+    public class ShieldSpecialist : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Vanguard Shield Specialist"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification"),
-					Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification"),
+                    Spell.Cast("Guard", on => Me.Companion, ret => Me.Companion != null && !Me.Companion.IsDead && !Me.Companion.HasBuff("Guard"))
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() >= 50),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 40),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Shoulder Cannon"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() >= 50),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 40),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Shoulder Cannon"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Storm", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Storm", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
 
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					new Decorator(ret => Me.ResourcePercent() < 60,
-						new PrioritySelector(
-							Spell.Cast("Energy Blast", ret => Me.BuffCount("Power Screen") == 3),
-							Spell.Cast("Pulse Cannon", ret => Me.HasBuff("Pulse Engine") && Me.CurrentTarget.Distance <= 1f),
-							Spell.Cast("Stockstrike", ret => Me.CurrentTarget.Distance <= .4f),
-							Spell.Cast("Explosive Surge", ret => Me.HasBuff("Static Surge") && Me.CurrentTarget.Distance <= 0.5f),
-							Spell.Cast("Hammer Shot")
-							)),
-					Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.CastOnGround("Smoke Grenade", ret => Me.CurrentTarget.Distance <= 0.8f),
-					Spell.Cast("Shoulder Cannon"),
-					Spell.Cast("Energy Blast", ret => Me.BuffCount("Power Screen") == 3),
-					Spell.Cast("Stockstrike"),
-					Spell.Cast("High Impact Bolt"),
-					Spell.Cast("Pulse Cannon", ret => Me.HasBuff("Pulse Engine") && Me.CurrentTarget.Distance <= 1f),
-					Spell.Cast("Explosive Surge", ret => Me.HasBuff("Static Surge") && Me.CurrentTarget.Distance <= 0.5f),
-					Spell.Cast("Ion Pulse"),
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-						Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-						Spell.CastOnGround("Artillery Blitz"),
-						Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
-						Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
-						Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
-						));
-			}
-		}
-	}
+                    //Rotation
+                    new Decorator(ret => Me.ResourcePercent() < 60,
+                        new PrioritySelector(
+                            Spell.Cast("Energy Blast", ret => Me.BuffCount("Power Screen") == 3),
+                            Spell.Cast("Pulse Cannon", ret => Me.HasBuff("Pulse Engine") && Me.CurrentTarget.Distance <= 1f),
+                            Spell.Cast("Stockstrike", ret => Me.CurrentTarget.Distance <= .4f),
+                            Spell.Cast("Explosive Surge", ret => Me.HasBuff("Static Surge") && Me.CurrentTarget.Distance <= 0.5f),
+                            Spell.Cast("Hammer Shot")
+                            )),
+                    Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.CastOnGround("Smoke Grenade", ret => Me.CurrentTarget.Distance <= 0.8f),
+                    Spell.Cast("Shoulder Cannon"),
+                    Spell.Cast("Energy Blast", ret => Me.BuffCount("Power Screen") == 3),
+                    Spell.Cast("Stockstrike"),
+                    Spell.Cast("High Impact Bolt"),
+                    Spell.Cast("Pulse Cannon", ret => Me.HasBuff("Pulse Engine") && Me.CurrentTarget.Distance <= 1f),
+                    Spell.Cast("Explosive Surge", ret => Me.HasBuff("Static Surge") && Me.CurrentTarget.Distance <= 0.5f),
+                    Spell.Cast("Ion Pulse"),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                        Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                        Spell.CastOnGround("Artillery Blitz"),
+                        Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
+                        Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
+                        Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Advanced/Vanguard/Tactics.cs
+++ b/trunk/DefaultCombat/Routines/Advanced/Vanguard/Tactics.cs
@@ -7,103 +7,103 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Tactics : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Vanguard Tactics"; }
-		}
+    public class Tactics : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Vanguard Tactics"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Tenacity", ret => Me.IsStunned),
-					Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() <= 50),
-					Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 60),
-					Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
-					Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 80),
-					Spell.Buff("Battle Focus"),
-					Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
-					Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Tenacity", ret => Me.IsStunned),
+                    Spell.Buff("Recharge Cells", ret => Me.ResourcePercent() <= 50),
+                    Spell.Buff("Reactive Shield", ret => Me.HealthPercent <= 60),
+                    Spell.Buff("Adrenaline Rush", ret => Me.HealthPercent <= 30),
+                    Spell.Buff("Reserve Powercell", ret => Me.ResourceStat <= 80),
+                    Spell.Buff("Battle Focus"),
+                    Spell.Cast("Unity", ret => Me.HealthPercent <= 15),
+                    Spell.Cast("Sacrifice", ret => Me.HealthPercent <= 5)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Storm", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
-					
-					//Movement
-					CombatMovement.CloseDistance(Distance.Melee),
-					
-					//Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
-					Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
-					Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
-					Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
-					
-					//Rotation
-					new Decorator(ret => Me.ResourcePercent() > 40,
-						new PrioritySelector(
-							Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Tactical Accelerator")),
-							Spell.Cast("Hammer Shot")
-							)),
-					Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
-					Spell.Cast("Cell Burst", ret => Me.BuffCount("Energy Lode") == 4),
-					Spell.Cast("High Impact Bolt",	ret => Me.CurrentTarget.HasDebuff("Bleeding (Gut)") && Me.HasBuff("Tactical Accelerator")),
-					Spell.DoT("Gut", "Bleeding (Gut)"),
-					Spell.Cast("Assault Plastique"),
-					Spell.Cast("Stock Strike"),
-					Spell.Cast("Tactical Surge", ret => Me.Level >= 26),
-					Spell.Cast("Ion Pulse", ret => Me.Level < 26),
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Storm", ret => Me.CurrentTarget.Distance >= 1f && !DefaultCombat.MovementDisabled),
 
-					//HK-55 Mode Rotation
-					Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
-					Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
-					Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
-					);
-			}
-		}
+                    //Movement
+                    CombatMovement.CloseDistance(Distance.Melee),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new PrioritySelector(
-					new Decorator(ret => Targeting.ShouldAoe,
-						new PrioritySelector(
-							Spell.CastOnGround("Artillery Blitz")
-							)),
-					new Decorator(ret => Targeting.ShouldPbaoe,
-						new PrioritySelector(
-							Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
-							Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
-							Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
- 							Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
- 							Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
-						)));
-			}
-		}
-	}
+                    //Legacy Heroic Moment Abilities --will only be active when user initiates Heroic Moment--
+                    Spell.Cast("Legacy Project", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Dirty Kick", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.4f),
+                    Spell.Cast("Legacy Sticky Plasma Grenade", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Flame Thrower", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Lightning", ret => Me.HasBuff("Heroic Moment")),
+                    Spell.Cast("Legacy Force Choke", ret => Me.HasBuff("Heroic Moment")),
+
+                    //Rotation
+                    new Decorator(ret => Me.ResourcePercent() > 40,
+                        new PrioritySelector(
+                            Spell.Cast("High Impact Bolt", ret => Me.HasBuff("Tactical Accelerator")),
+                            Spell.Cast("Hammer Shot")
+                            )),
+                    Spell.Cast("Riot Strike", ret => Me.CurrentTarget.IsCasting && CombatHotkeys.EnableInterrupts),
+                    Spell.Cast("Cell Burst", ret => Me.BuffCount("Energy Lode") == 4),
+                    Spell.Cast("High Impact Bolt", ret => Me.CurrentTarget.HasDebuff("Bleeding (Gut)") && Me.HasBuff("Tactical Accelerator")),
+                    Spell.DoT("Gut", "Bleeding (Gut)"),
+                    Spell.Cast("Assault Plastique"),
+                    Spell.Cast("Stock Strike"),
+                    Spell.Cast("Tactical Surge", ret => Me.Level >= 26),
+                    Spell.Cast("Ion Pulse", ret => Me.Level < 26),
+
+                    //HK-55 Mode Rotation
+                    Spell.Cast("Charging In", ret => Me.CurrentTarget.Distance >= .4f && Me.InCombat && CombatHotkeys.EnableHK55),
+                    Spell.Cast("Blindside", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Assassinate", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rail Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Rifle Blast", ret => CombatHotkeys.EnableHK55),
+                    Spell.Cast("Execute", ret => Me.CurrentTarget.HealthPercent <= 45 && CombatHotkeys.EnableHK55)
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new PrioritySelector(
+                    new Decorator(ret => Targeting.ShouldAoe,
+                        new PrioritySelector(
+                            Spell.CastOnGround("Artillery Blitz")
+                            )),
+                    new Decorator(ret => Targeting.ShouldPbaoe,
+                        new PrioritySelector(
+                            Spell.Cast("Legacy Force Sweep", ret => Me.HasBuff("Heroic Moment") && Me.CurrentTarget.Distance <= 0.5f), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Legacy Orbital Strike", ret => Me.HasBuff("Heroic Moment")), //--will only be active when user initiates Heroic Moment--
+                            Spell.CastOnGround("Terminate", ret => CombatHotkeys.EnableHK55), //--will only be active when user initiates HK-55 Mode
+                            Spell.Cast("Ion Wave", ret => Me.CurrentTarget.Distance <= 1f),
+                             Spell.Cast("Flak Shell", ret => Me.CurrentTarget.Distance <= 1f),
+                             Spell.Cast("Explosive Surge", ret => Me.CurrentTarget.Distance <= .5f)
+                        )));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Agent.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Agent.cs
@@ -7,50 +7,50 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Agent : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Agent"; }
-		}
+    public class Agent : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Agent"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Coordination")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Coordination")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Melee),
-					Spell.DoT("Corrosive Dart", "", 15000),
-					Spell.Cast("Explosive Probe"),
-					Spell.Cast("Rifle Shot")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Melee),
+                    Spell.DoT("Corrosive Dart", "", 15000),
+                    Spell.Cast("Explosive Probe"),
+                    Spell.Cast("Rifle Shot")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Fragmentation Grenade", ret => Me.CurrentTarget.Distance <= Distance.Ranged)
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Fragmentation Grenade", ret => Me.CurrentTarget.Distance <= Distance.Ranged)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/BountyHunter.cs
+++ b/trunk/DefaultCombat/Routines/Basic/BountyHunter.cs
@@ -7,49 +7,49 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class BountyHunter : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Bounty Hunter"; }
-		}
+    public class BountyHunter : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Bounty Hunter"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Hunter's Boon")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Hunter's Boon")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Ranged),
-					Spell.Cast("Rail Shot"),
-					Spell.Cast("Vent Heat", ret => Me.ResourcePercent() >= 50),
-					Spell.Cast("Flame Burst", ret => Me.ResourcePercent() <= 50),
-					Spell.Cast("Rapid Shots")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Ranged),
+                    Spell.Cast("Rail Shot"),
+                    Spell.Cast("Vent Heat", ret => Me.ResourcePercent() >= 50),
+                    Spell.Cast("Flame Burst", ret => Me.ResourcePercent() <= 50),
+                    Spell.Cast("Rapid Shots")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector());
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector());
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Consular.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Consular.cs
@@ -7,44 +7,44 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Consular : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Consular"; }
-		}
+    public class Consular : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Consular"; }
+        }
 
-		public override Composite Buffs
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Buffs
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Melee),
-					Spell.Cast("Project", ret => Me.Force > 75),
-					Spell.Cast("Saber Strike")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Melee),
+                    Spell.Cast("Project", ret => Me.Force > 75),
+                    Spell.Cast("Saber Strike")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Force Wave", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE))
-					);
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Force Wave", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE))
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Inquisitor.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Inquisitor.cs
@@ -7,49 +7,49 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Inquisitor : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Inquisitor"; }
-		}
+    public class Inquisitor : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Inquisitor"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Mark of Power")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Mark of Power")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Melee),
-					Spell.Cast("Shock", ret => Me.Force > 75),
-					Spell.Cast("Saber Strike")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Melee),
+                    Spell.Cast("Shock", ret => Me.Force > 75),
+                    Spell.Cast("Saber Strike")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Overload", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE)
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Overload", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Knight.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Knight.cs
@@ -7,59 +7,59 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Knight : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Knight"; }
-		}
+    public class Knight : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Knight"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Force Leap", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance > 1f && Me.CurrentTarget.Distance <= 3f),
-					
-					
-				CombatMovement.CloseDistance(Distance.Melee),
-					Spell.Cast("Master Strike"),
-					Spell.Cast("Blade Storm"),
-					Spell.Cast("Riposte"),
-					Spell.Cast("Slash", ret => Me.ActionPoints >= 7),
-					Spell.Cast("Strike")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Force Leap", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance > 1f && Me.CurrentTarget.Distance <= 3f),
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Force Sweep", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE))
-					);
-			}
-		}
-	}
+
+                CombatMovement.CloseDistance(Distance.Melee),
+                    Spell.Cast("Master Strike"),
+                    Spell.Cast("Blade Storm"),
+                    Spell.Cast("Riposte"),
+                    Spell.Cast("Slash", ret => Me.ActionPoints >= 7),
+                    Spell.Cast("Strike")
+                    );
+            }
+        }
+
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Force Sweep", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE))
+                    );
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Smuggler.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Smuggler.cs
@@ -7,55 +7,55 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Smuggler : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Smuggler"; }
-		}
+    public class Smuggler : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Smuggler"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Lucky Shots")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Lucky Shots")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70)
-					);
-			}
-		}
+        public override Composite Cooldowns
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70)
+                    );
+            }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Ranged),
-					Spell.DoT("Vital Shot", "Bleeding (Vital Shot)"),
-					Spell.Cast("Sabotage Charge"),
-					Spell.Cast("Flurry of Bolts")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Ranged),
+                    Spell.DoT("Vital Shot", "Bleeding (Vital Shot)"),
+                    Spell.Cast("Sabotage Charge"),
+                    Spell.Cast("Flurry of Bolts")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector(
-						Spell.Cast("Thermal Grenade", ret => Me.CurrentTarget.Distance <= Distance.Ranged)
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector(
+                        Spell.Cast("Thermal Grenade", ret => Me.CurrentTarget.Distance <= Distance.Ranged)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Trooper.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Trooper.cs
@@ -7,49 +7,49 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Trooper : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Trooper"; }
-		}
+    public class Trooper : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Trooper"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Fortification")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Fortification")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					CombatMovement.CloseDistance(Distance.Ranged),
-					Spell.Cast("High Impact Bolt"),
-					Spell.Cast("Recharge Cells", ret => Me.ResourcePercent() <= 50),
-					Spell.Cast("Ion Pulse", ret => Me.ResourcePercent() >= 50),
-					Spell.Cast("Hammer Shot")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    CombatMovement.CloseDistance(Distance.Ranged),
+                    Spell.Cast("High Impact Bolt"),
+                    Spell.Cast("Recharge Cells", ret => Me.ResourcePercent() <= 50),
+                    Spell.Cast("Ion Pulse", ret => Me.ResourcePercent() >= 50),
+                    Spell.Cast("Hammer Shot")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldAoe,
-					new PrioritySelector());
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldAoe,
+                    new PrioritySelector());
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/Basic/Warrior.cs
+++ b/trunk/DefaultCombat/Routines/Basic/Warrior.cs
@@ -7,54 +7,54 @@ using DefaultCombat.Helpers;
 
 namespace DefaultCombat.Routines
 {
-	public class Warrior : RotationBase
-	{
-		public override string Name
-		{
-			get { return "Basic Warrior"; }
-		}
+    public class Warrior : RotationBase
+    {
+        public override string Name
+        {
+            get { return "Basic Warrior"; }
+        }
 
-		public override Composite Buffs
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Buff("Unnatural Might")
-					);
-			}
-		}
+        public override Composite Buffs
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Buff("Unnatural Might")
+                    );
+            }
+        }
 
-		public override Composite Cooldowns
-		{
-			get { return new PrioritySelector(); }
-		}
+        public override Composite Cooldowns
+        {
+            get { return new PrioritySelector(); }
+        }
 
-		public override Composite SingleTarget
-		{
-			get
-			{
-				return new PrioritySelector(
-					Spell.Cast("Force Charge", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance > 1f && Me.CurrentTarget.Distance <= 3f),
-					CombatMovement.CloseDistance(Distance.Melee),
-					Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70),
-					Spell.Cast("Ravage"),
-					Spell.Cast("Force Scream"),
-					Spell.Cast("Retaliation"),
-					Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 7),
-					Spell.Cast("Assault")
-					);
-			}
-		}
+        public override Composite SingleTarget
+        {
+            get
+            {
+                return new PrioritySelector(
+                    Spell.Cast("Force Charge", ret => !DefaultCombat.MovementDisabled && Me.CurrentTarget.Distance > 1f && Me.CurrentTarget.Distance <= 3f),
+                    CombatMovement.CloseDistance(Distance.Melee),
+                    Spell.Cast("Saber Ward", ret => Me.HealthPercent <= 70),
+                    Spell.Cast("Ravage"),
+                    Spell.Cast("Force Scream"),
+                    Spell.Cast("Retaliation"),
+                    Spell.Cast("Vicious Slash", ret => Me.ActionPoints >= 7),
+                    Spell.Cast("Assault")
+                    );
+            }
+        }
 
-		public override Composite AreaOfEffect
-		{
-			get
-			{
-				return new Decorator(ret => Targeting.ShouldPbaoe,
-					new PrioritySelector(
-						Spell.Cast("Smash", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE)
-						));
-			}
-		}
-	}
+        public override Composite AreaOfEffect
+        {
+            get
+            {
+                return new Decorator(ret => Targeting.ShouldPbaoe,
+                    new PrioritySelector(
+                        Spell.Cast("Smash", ret => Me.CurrentTarget.Distance <= Distance.MeleeAoE)
+                        ));
+            }
+        }
+    }
 }

--- a/trunk/DefaultCombat/Routines/RotationBase.cs
+++ b/trunk/DefaultCombat/Routines/RotationBase.cs
@@ -8,55 +8,55 @@ using DefaultCombat.Core;
 
 namespace DefaultCombat.Routines
 {
-	public abstract class RotationBase
-	{
-		/// <summary>
-		///     Gets the local player.
-		/// </summary>
-		protected static TorPlayer Me
-		{
-			get { return BuddyTor.Me; }
-		}
+    public abstract class RotationBase
+    {
+        /// <summary>
+        ///     Gets the local player.
+        /// </summary>
+        protected static TorPlayer Me
+        {
+            get { return BuddyTor.Me; }
+        }
 
-		/// <summary>
-		///     Gets the character functioning as the tank.
-		/// </summary>
-		public static TorCharacter Tank
-		{
-			get { return Targeting.Tank; }
-		}
+        /// <summary>
+        ///     Gets the character functioning as the tank.
+        /// </summary>
+        public static TorCharacter Tank
+        {
+            get { return Targeting.Tank; }
+        }
 
-		/// <summary>
-		///     Gets the current heal target.
-		/// </summary>
-		public static TorCharacter HealTarget
-		{
-			get { return Targeting.HealTarget; }
-		}
+        /// <summary>
+        ///     Gets the current heal target.
+        /// </summary>
+        public static TorCharacter HealTarget
+        {
+            get { return Targeting.HealTarget; }
+        }
 
-		/// <summary>
-		///     Gets the rotation's name.
-		/// </summary>
-		public abstract string Name { get; }
+        /// <summary>
+        ///     Gets the rotation's name.
+        /// </summary>
+        public abstract string Name { get; }
 
-		/// <summary>
-		///     Gets the buff logic for this routine.
-		/// </summary>
-		public abstract Composite Buffs { get; }
+        /// <summary>
+        ///     Gets the buff logic for this routine.
+        /// </summary>
+        public abstract Composite Buffs { get; }
 
-		/// <summary>
-		///     Gets the cooldown usage logic for this routine.
-		/// </summary>
-		public abstract Composite Cooldowns { get; }
+        /// <summary>
+        ///     Gets the cooldown usage logic for this routine.
+        /// </summary>
+        public abstract Composite Cooldowns { get; }
 
-		/// <summary>
-		///     Gets the single target logic for this routine.
-		/// </summary>
-		public abstract Composite SingleTarget { get; }
+        /// <summary>
+        ///     Gets the single target logic for this routine.
+        /// </summary>
+        public abstract Composite SingleTarget { get; }
 
-		/// <summary>
-		///     Gets the area of effect logic for this routine.
-		/// </summary>
-		public abstract Composite AreaOfEffect { get; }
-	}
+        /// <summary>
+        ///     Gets the area of effect logic for this routine.
+        /// </summary>
+        public abstract Composite AreaOfEffect { get; }
+    }
 }


### PR DESCRIPTION
Updates In This Release : 78
*Juggernaut Rage optimized single target rotation, 500 dps increase (thanks Lynx)
*Juggernaut Rage optimized AoE rotation
*Guardian Focus optimized single target rotation, 825 dps increase
*Guardian Focus fixed incorrect spelling in AoE rotation, optimized rotation
*Juggernaut Vengeance optimized single target rotation (thanks JNBackup)
*Juggernaut Vengeance added Vengeful Slam and Chilling Scream, 400 dps increase
*Juggernaut Vengeance fixed terrible AoE, added missing spells and removed Smash how did that get in there???
*Guardian Vigilance optimized single and AoE, increased single target by 800 dps
*Marauder Fury re-order of some abilities to improve DPS (I do not have a toon to test this) (thanks JNBackup)
*Marauder Fury changed Raging Burst ability to use Destruction 'or' Dominate, added missing AoE rotation abilities
*Marauder Fury made class lower level friendly with Assault arguments
*Shadow Infiltration optimized single target rotation, 400 dps increase (thanks Lynx) (we still have a bug causing Clairvoyant Strike Spam)
*Sorcerer Lightning added opened, optimized dps rotation (thanks JNBackup)